### PR TITLE
Add claude-starter: Production-ready configuration template

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 - [finishing-a-development-branch](https://github.com/obra/superpowers/tree/main/skills/finishing-a-development-branch) - Guides completion of development work by presenting clear options and handling chosen workflow.
 - [pypict-claude-skill](https://github.com/omkamal/pypict-claude-skill) - Design comprehensive test cases using PICT (Pairwise Independent Combinatorial Testing) for requirements or code, generating optimized test suites with pairwise coverage.
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
+- [claude-starter](https://github.com/raintree-technology/claude-starter) - Production-ready Claude Code configuration template with 40 auto-activating skills across 8 domains, TOON format support for 30-60% token savings, and native Zig encoder/decoder.
 - [move-code-quality-skill](https://github.com/1NickPappas/move-code-quality-skill) - Analyzes Move language packages against the official Move Book Code Quality Checklist for Move 2024 Edition compliance and best practices.
 - [claude-code-terminal-title](https://github.com/bluzername/claude-code-terminal-title) - Gives each Claud Code terminal window a dynamic title that describes the work being done so you don't lose track of what terminal window is doing what.
 


### PR DESCRIPTION
## Description

This PR adds **[claude-starter](https://github.com/raintree-technology/claude-starter)** to the **Development & Code Tools** section.

## What is claude-starter?

A production-ready Claude Code configuration template that provides:

- **40 auto-activating skills** organized across 8 domains
- **TOON format support** for 30-60% token savings on tabular data
- **7 slash commands** for format conversion and marketplace integration
- **Native Zig encoder/decoder** (20x faster than JavaScript)
- **Complete documentation** with examples

## Features

**8 Skill Domains (40 total):**
1. **AI & Claude Code** (7 skills) - Anthropic API, Claude Code CLI, builders
2. **Payments & Commerce** (3 skills) - Stripe, Whop, Shopify
3. **Banking** (5 skills) - Plaid with Auth, Transactions, Identity, Accounts
4. **Blockchain** (18 skills) - Aptos, Shelby Protocol, Decibel
5. **Backend** (1 skill) - Supabase
6. **Mobile** (5 skills) - Expo, iOS
7. **Data** (1 skill) - TOON formatter

**TOON Format:**
- 30-60% token savings on arrays and uniform objects
- Native Zig implementation (357KB binary)
- 5 slash commands: `/convert-to-toon`, `/toon-encode`, `/toon-decode`, `/toon-validate`, `/analyze-tokens`

## Installation

**Full template:**
```bash
cp -r claude-starter/.claude /your-project/.claude
```

**Selective:**
```bash
cp -r claude-starter/.claude/skills/{stripe,supabase} /your-project/.claude/skills/
```

**TOON tools only:**
```bash
cp -r claude-starter/.claude/utils/toon /your-project/.claude/utils/
cp -r claude-starter/.claude/commands/toon* /your-project/.claude/commands/
```

## Links

- **Repository:** https://github.com/raintree-technology/claude-starter
- **License:** MIT

## Checklist

- [x] Added to appropriate category (Development & Code Tools)
- [x] Follows formatting (link, description)
- [x] Repository is public
- [x] MIT License
- [x] Skills follow Claude Code best practices