### PR TITLE
Add Plugin Marketplace section with claude-night-market

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # Awesome Claude Skills
 
-## 📚 Table of Contents  
-- [Document Skills](#-document-skills)  
-- [Development & Code Tools](#-development--code-tools)  
-- [Data & Analysis](#-data--analysis)  
-- [Scientific & Research Tools](#-scientific--research-tools)  
-- [Writing & Research](#-writing--research)  
-- [Learning & Knowledge](#-learning--knowledge)  
-- [Media & Content](#-media--content)  
-- [Collaboration & Project Management](#-collaboration--project-management)  
-- [Security & Web Testing](#-security--web-testing)  
+## 📚 Table of Contents
+- [Document Skills](#-document-skills)
+- [Development & Code Tools](#-development--code-tools)
+- [Data & Analysis](#-data--analysis)
+- [Scientific & Research Tools](#-scientific--research-tools)
+- [Writing & Research](#-writing--research)
+- [Learning & Knowledge](#-learning--knowledge)
+- [Media & Content](#-media--content)
+- [Collaboration & Project Management](#-collaboration--project-management)
+- [Security & Web Testing](#-security--web-testing)
 - [Utility & Automation](#-utility--automation)
+- [Plugin Marketplace](#-plugin-marketplace)
 
 
 ## 📄 Document Skills  
@@ -90,8 +91,17 @@
 ## 🔧 Utility & Automation  
 - [file-organizer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/file-organizer) - Intelligently organizes your files and folders across your computer.
 - [invoice-organizer](https://github.com/ComposioHQ/awesome-claude-skills/blob/master/invoice-organizer/SKILL.md) - Automatically organizes invoices and receipts for tax preparation
-- [skill-creator](https://github.com/anthropics/skills/tree/main/skill-creator) - Template / helper to build new Claude skills.  
-- [template-skill](https://github.com/anthropics/skills/tree/main/template-skill) - Minimal skeleton for a new skill project structure.  
+- [skill-creator](https://github.com/anthropics/skills/tree/main/skill-creator) - Template / helper to build new Claude skills.
+- [template-skill](https://github.com/anthropics/skills/tree/main/template-skill) - Minimal skeleton for a new skill project structure.
+
+
+## 🏪 Plugin Marketplace
+
+Installable plugin collections for Claude Code that bundle multiple skills, commands, agents, and hooks.
+
+- [superpowers](https://github.com/obra/superpowers) - Core skills library for Claude Code with 20+ battle-tested skills including TDD, debugging, and collaboration patterns. Features `/brainstorm`, `/write-plan`, `/execute-plan` commands. Install: `/plugin marketplace add obra/superpowers-marketplace`
+- [claude-night-market](https://github.com/athola/claude-night-market) - Modular plugin ecosystem with 12+ specialized plugins for Claude Code workflows. See [Capabilities Reference](https://github.com/athola/claude-night-market/blob/master/docs/capabilities-reference.md) for full list of skills, commands, agents, and hooks. Install: `/plugin marketplace add athola/claude-night-market`
+
 
 ## 🤝 Contribution
 


### PR DESCRIPTION
## Summary

Adds a new **Plugin Marketplace** section for installable plugin collections that bundle multiple skills, commands, agents, and hooks for Claude Code.

## Changes

1. Added "Plugin Marketplace" to the Table of Contents
2. Created new `## 🏪 Plugin Marketplace` section before Contribution
3. Added [claude-night-market](https://github.com/athola/claude-night-market) as the first entry

## About the New Section

Plugin Marketplace entries differ from individual skills - they are complete plugin ecosystems installable via `/plugin marketplace add`. This section provides a place for these larger collections.

## About claude-night-market

Modular plugin ecosystem with 12+ specialized plugins for Claude Code workflows, including:
- Meta-skills development (abstract)
- Architecture patterns (archetypes)
- Context optimization (conservation)
- Code review (pensive)
- Git operations (sanctum)
- And more...

See the [Capabilities Reference](https://github.com/athola/claude-night-market/blob/master/docs/capabilities-reference.md) for the full list.

**Installation:** `/plugin marketplace add athola/claude-night-market`