### PR TITLE
Add postgres and imagen skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@
 
 
 
-## 📊 Data & Analysis  
-- [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger 
+## 📊 Data & Analysis
+- [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger
 - [csv-data-summarizer-claude-skill](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSVs: columns, distributions, missing data, correlations.
+- [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security.
 
 
 
@@ -64,10 +65,11 @@
 
 
 
-## 🎬 Media & Content  
-- [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.  
+## 🎬 Media & Content
+- [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [video-downloader](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/video-downloader) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival.
 - [image-enhancer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/image-enhancer) - Improves the quality of images, especially screenshots.
+- [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, and visual assets.
 - [claude-epub-skill](https://github.com/smerchek/claude-epub-skill) - Parse and analyze EPUB ebook contents for querying or summarizing.
 
 


### PR DESCRIPTION
## New Skills

Adding two skills from [ai-skills](https://github.com/sanjay3290/ai-skills):

### postgres (📊 Data & Analysis)
- Execute safe read-only SQL queries against PostgreSQL databases
- Multi-database connection support with intelligent auto-selection
- Defense-in-depth security (read-only session + query validation)

### imagen (🎬 Media & Content)
- Generate images using Google Gemini's image generation API
- UI mockups, icons, illustrations, and visual assets
- Cross-platform (Windows, macOS, Linux)

Both skills tested with Claude Code.