### PR TITLE
Add Trail of Bits Security Skills to Security & Web Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@
 - [defense-in-depth](https://github.com/obra/superpowers/blob/main/skills/defense-in-depth) - Implement multi-layered testing and security best practices.
 - [ffuf_claude_skill](https://github.com/jthack/ffuf_claude_skill) - Integrate Claude with FFUF (fuzzing) and analyze results for vulnerabilities.
 - [systematic-debugging](https://github.com/obra/superpowers/blob/main/skills/systematic-debugging) - Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes
+- [Trail of Bits Security Skills](https://github.com/trailofbits/skills) - Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and fix verification.
 - [varlock-claude-skill](https://github.com/wrsmith108/varlock-claude-skill) - Secure environment variable management ensuring secrets never appear in Claude sessions, terminals, logs, or git commits.
 - [webapp-testing](https://github.com/anthropics/skills/tree/main/skills/webapp-testing) - Toolkit for interacting with and testing local web applications using Playwright.
 


### PR DESCRIPTION
Adds Trail of Bits Security Skills to the Security & Web Testing section.

**Skill:** [Trail of Bits Security Skills](https://github.com/trailofbits/skills)

**Description:** Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and fix verification.

**Features:**
- 17 security-focused skills
- Static analysis toolkit integration
- Variant analysis across codebases
- Fix verification and differential code review

Licensed under CC BY-SA 4.0.