### PR TITLE
Add outline skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@
 - [meeting-insights-analyzer](https://github.com/ComposioHQ/awesome-claude-skills/blob/master/meeting-insights-analyzer/) - Transforms your meeting transcripts into actionable insights about your communication patterns
 - [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/review-implementing) - Evaluate code implementation plans and align with specs.
 - [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/test-fixing) - Detect failing tests and propose patches or fixes.
+- [outline](https://github.com/sanjay3290/ai-skills/tree/main/skills/outline) - Search, read, create, and manage documents in Outline wiki instances (cloud or self-hosted).
 
 
 ## 🛡 Security & Web Testing


### PR DESCRIPTION
## New Skill: outline

Adding the Outline wiki skill to Collaboration & Project Management section.

### Skill Details
- **Repository**: https://github.com/sanjay3290/ai-skills/tree/main/skills/outline
- **Description**: Search, read, create, and manage documents in Outline wiki instances

### Features
- Full-text search across all documents
- CRUD operations for documents
- Collection browsing and management
- Export documents as markdown
- Works with both Outline Cloud and self-hosted instances

From the [ai-skills](https://github.com/sanjay3290/ai-skills) collection.