### PR TITLE
Add HashiCorp Terraform Claude skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 - [plugin-authoring](https://github.com/ivan-magda/claude-code-plugin-template/tree/main/plugins/plugin-development/skills/plugin-authoring) - Ambient guidance for creating, modifying, and debugging Claude Code plugins with schemas, templates, validation workflows, and troubleshooting.
 - [claude-skills](https://github.com/jeffallan/claude-skills) - 65 full-stack development skills with progressive disclosure, covering React, NestJS, Python, DevOps, and 30+ frameworks.
 - [jules](https://github.com/sanjay3290/ai-skills/tree/main/skills/jules) - Delegate coding tasks to Google Jules AI agent for async bug fixes, documentation, tests, and feature implementation on GitHub repos.
+- [hashicorp-agent-skills](https://github.com/hashicorp/agent-skills) - HashiCorp-maintained Claude skills for Terraform workflows and infrastructure automation.
 
 
 


### PR DESCRIPTION
Summary: Add HashiCorp-maintained Terraform/infra Claude skills to Development & Code Tools.
Change: New entry for hashicorp/agent-skills with a brief description.