### PR TITLE
Add manus skill for delegating tasks to Manus AI agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 - [claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills) - 125+ scientific skills for bioinformatics, cheminformatics, clinical research, and machine learning.
 - [materials-simulation-skills](https://github.com/HeshamFS/materials-simulation-skills) - Agent skills for computational materials science: numerical stability, time-stepping, linear solvers, mesh generation, simulation validation, parameter optimization, and post-processing.
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews.
+- [manus](https://github.com/sanjay3290/ai-skills/tree/main/skills/manus) - Delegate complex tasks to Manus AI agent for deep research, market analysis, product comparisons, stock analysis, and comprehensive report generation with parallel processing.
 
 
 ## ✍️ Writing & Research  


### PR DESCRIPTION
Adds [manus](https://github.com/sanjay3290/ai-skills/tree/main/skills/manus) skill to the Scientific & Research Tools section.

**About Manus:**
- Deep research with parallel processing
- Market analysis, competitive landscaping
- Stock/financial analysis with charts
- Comprehensive report generation

Category: 🔬 Scientific & Research Tools