### PR TITLE
Add upload-post skill for social media publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 - [claude-skills](https://github.com/jeffallan/claude-skills) - 65 full-stack development skills with progressive disclosure, covering React, NestJS, Python, DevOps, and 30+ frameworks.
 - [jules](https://github.com/sanjay3290/ai-skills/tree/main/skills/jules) - Delegate coding tasks to Google Jules AI agent for async bug fixes, documentation, tests, and feature implementation on GitHub repos.
 - [hashicorp-agent-skills](https://github.com/hashicorp/agent-skills) - HashiCorp-maintained Claude skills for Terraform workflows and infrastructure automation.
+- [upload-post](https://github.com/moltbot/upload-post-skill) - Publish videos and photos to 10+ social platforms (TikTok, Instagram, YouTube, LinkedIn, Facebook, X, Threads, Pinterest, Reddit, Bluesky) with a single API call. Supports scheduling, async uploads, and webhooks.
 
 
 


### PR DESCRIPTION
## Description

Adds the upload-post skill for automating social media content publishing.

## What it does

- Publishes videos and photos to 10+ platforms (TikTok, Instagram, YouTube, LinkedIn, Facebook, X, Threads, Pinterest, Reddit, Bluesky)
- Single API call for multi-platform posting
- Content scheduling and queue management
- Async uploads with status polling
- Webhook notifications for upload completion

## Category

Added to **Development & Code Tools** section.

## Resources

- Documentation: https://docs.upload-post.com
- Skill Repository: https://github.com/moltbot/upload-post-skill
- Website: https://upload-post.com