### PR TITLE
Add kanban-skill to Collaboration & Project Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@
 
 ## 🤝 Collaboration & Project Management
 - [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/git-pushing) - Automate git operations and repository interactions.
+- [kanban-skill](https://github.com/mattjoyce/kanban-skill) - Markdown-based Kanban board with file-based cards, YAML frontmatter for status/priority/dependencies, and no database required.
 - [linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams with MCP tools, SDK scripts, and GraphQL fallbacks for reliable project tracking.
 - [linear-cli-skill](https://github.com/Valian/linear-cli-skill) - A skill teaching claude how to use linear-CLI (provided alongside the skill), meant to replace linear MCP.
 - [meeting-insights-analyzer](https://github.com/ComposioHQ/awesome-claude-skills/blob/master/meeting-insights-analyzer/) - Transforms your meeting transcripts into actionable insights about your communication patterns


### PR DESCRIPTION
## Summary
Adds [kanban-skill](https://github.com/mattjoyce/kanban-skill) to the Collaboration & Project Management section.

kanban-skill is a Markdown-based Kanban board for Claude Code that uses file-based cards with YAML frontmatter for tracking status, priority, and dependencies - no database required.

## Changes
- Added kanban-skill entry to the Collaboration & Project Management section
- Positioned alphabetically after git-pushing

🤖 Generated with [Claude Code](https://claude.com/claude-code)