### PR TITLE
Add ClawFu: 169 expert-sourced marketing skills (MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@
 
 
 ## 🗂️ Collections
+- [@clawfu/mcp-skills](https://github.com/guia-matthieu/clawfu-skills) - 169 expert-sourced marketing skills (Dunford, Schwartz, Ogilvy, Cialdini) as MCP server with brand memory.
 
 ## 🤝 Contribution
 


### PR DESCRIPTION
Adds [ClawFu](https://github.com/guia-matthieu/clawfu-skills) to the **Collections** section.

**What it is:** An MCP server with 169 expert-sourced marketing skills (Dunford, Schwartz, Ogilvy, Cialdini) with brand memory for voice consistency.

- npm: `@clawfu/mcp-skills`
- License: MIT
- Website: https://clawfu.com