### PR TITLE
Add Product-Manager-Skills to collaboration/project management section

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@
 - [claude-skills](https://github.com/jeffallan/claude-skills) - 9 project workflow commands (discovery, planning, execution, retrospectives) with Jira/Confluence integration.
 - [outline](https://github.com/sanjay3290/ai-skills/tree/main/skills/outline) - Search, read, create, and manage documents in Outline wiki instances (cloud or self-hosted).
 - [google-workspace-skills](https://github.com/sanjay3290/ai-skills/tree/main/skills) - Suite of Google Workspace integrations: Gmail, Google Calendar, Google Chat, Google Docs, Google Sheets, Google Slides, and Google Drive. Lightweight alternatives to full MCP servers with cross-platform OAuth.
+- [Product-Manager-Skills](https://github.com/deanpeters/Product-Manager-Skills) - Product management skill library covering discovery, prioritization, PRDs, roadmap planning, and SaaS metrics.
 
 
 ## 🛡 Security & Web Testing


### PR DESCRIPTION
This PR adds `deanpeters/Product-Manager-Skills` to the Community Skills table.

Why this belongs:
- +40 PM-focused skills collection covering problem framing, discovery, opportunity selection,roadmaps, PRDs, prototypes, story splitting, and SaaS metrics.
- Public repo with active usage and social proof (21 stars as of Feb 11, 2026)
- Non-commercial, standalone value for Claude/Codex users
