### PR TITLE
Add elevenlabs text-to-speech and podcast skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@
 - [video-downloader](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/video-downloader) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival.
 - [image-enhancer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/image-enhancer) - Improves the quality of images, especially screenshots.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, and visual assets.
+- [elevenlabs](https://github.com/sanjay3290/ai-skills/tree/main/skills/elevenlabs) - Text-to-speech narration and two-host podcast generation from documents using ElevenLabs API.
 - [claude-epub-skill](https://github.com/smerchek/claude-epub-skill) - Convert markdown documents, chat summaries, or research reports into a downloadable epub file that can be sent to Kindle.
 - [video-prompting-skill](https://github.com/Square-Zero-Labs/video-prompting-skill) - Draft and refine prompts for video generation models (LTX-2, Sora, Veo 3, etc.) 
 


### PR DESCRIPTION
## New Skill: elevenlabs

Adding [elevenlabs](https://github.com/sanjay3290/ai-skills/tree/main/skills/elevenlabs) to the **Media & Content** section.

### What it does
- **Single-voice narration**: Convert documents (PDF, DOCX, MD, TXT) to spoken audio using ElevenLabs TTS API
- **Two-host podcast**: Generate conversational podcasts from documents with two distinct AI voices
- Sentence-aware text chunking with voice continuity across chunks
- ffmpeg-based audio concatenation

### Category
Media & Content (placed next to imagen)