### PR TITLE
Add pm-skills to Collaboration & Project Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@
 - [claude-skills](https://github.com/jeffallan/claude-skills) - 9 project workflow commands (discovery, planning, execution, retrospectives) with Jira/Confluence integration.
 - [outline](https://github.com/sanjay3290/ai-skills/tree/main/skills/outline) - Search, read, create, and manage documents in Outline wiki instances (cloud or self-hosted).
 - [google-workspace-skills](https://github.com/sanjay3290/ai-skills/tree/main/skills) - Suite of Google Workspace integrations: Gmail, Google Calendar, Google Chat, Google Docs, Google Sheets, Google Slides, and Google Drive. Lightweight alternatives to full MCP servers with cross-platform OAuth.
+- [pm-skills](https://github.com/product-on-purpose/pm-skills) - 24 product management skills across the Triple Diamond lifecycle with agentskills.io spec compliance, templates, and MCP server support.
 - [Product-Manager-Skills](https://github.com/deanpeters/Product-Manager-Skills) - Product management skill library covering discovery, prioritization, PRDs, roadmap planning, and SaaS metrics.
 
 


### PR DESCRIPTION
## Summary

Adding [pm-skills](https://github.com/product-on-purpose/pm-skills) to the
**Collaboration & Project Management** section.

**pm-skills** is a curated library of 24 plug-and-play product management agent
skills organized across the six phases of the Triple Diamond framework (Discover,
Define, Ideate, Design, Deliver, Measure). It follows the
[agentskills.io specification](https://agentskills.io/specification) and ships
with templates, workflow bundles, and a companion
[MCP server](https://github.com/product-on-purpose/pm-skills-mcp).

## Why this belongs

- 24 PM-focused skills covering the complete product lifecycle end to end
- Compliant with the agentskills.io open specification
- Apache 2.0 licensed, active development (v2.2.0)
- Companion MCP server for Claude Desktop, VS Code, and CLI integration
- Complements the existing Product-Manager-Skills entry with a different
  organizational model (Triple Diamond phases vs. method-based framework)

## Changes

- Added pm-skills entry to the Collaboration & Project Management section