### PR TITLE
Add task-observer skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@
 - [skill-creator](https://github.com/anthropics/skills/tree/main/skills/skill-creator) - Template / helper to build new Claude skills.  
 - [template-skill](https://github.com/anthropics/skills/tree/main/template) - Minimal skeleton for a new skill project structure.
 - [agentfund-mcp](https://github.com/RioTheGreat-ai/agentfund-mcp) - Crowdfunding for AI agents. Milestone-based escrow on Base chain for proposals, project tracking, and payments.
-- [task-observer](https://github.com/rebelytics/one-skill-to-rule-them-all) - One skill to rule them all: A meta-skill that watches your work sessions, captures corrections and judgment calls, and turns them into improvements for your other skills. Also identifies new skill candidates from your work patterns.  
+- [task-observer](https://github.com/rebelytics/one-skill-to-rule-them-all) - A meta-skill that builds and improves all your skills, including itself.
 **[glitternetwork/pinme](https://github.com/glitternetwork/skills/tree/main/pinme)** - PinMe is a zero-config frontend deployment tool. No servers. No accounts. No setup.
 
 ## 📰 Articles & Blog Posts 


### PR DESCRIPTION
This is a meta-skill I created and open-sourced today. It watches task-related work sessions, captures corrections and judgment calls, and turns them into skill improvements and new skill candidates. Built for Claude Cowork, but also compatible with other environments (with possible caveats).