### PR TITLE
Add TasteRay elicitation and recommendations skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@
 - [notebooklm](https://github.com/sanjay3290/ai-skills/tree/main/skills/notebooklm) - Query and manage Google NotebookLM notebooks with persistent auth, batch/multi queries, source sync, and structured exports.
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security.
 - [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection.
+- [elicitation](https://github.com/tasteray/skills/tree/main/elicitation) - Psychological profiling through natural conversation using narrative identity and Motivational Interviewing techniques.
+- [recommendations](https://github.com/tasteray/skills/tree/main/recommendations) - Personalized recommendations across movies, restaurants, products, travel, and jobs via the TasteRay API.
 
 
 


### PR DESCRIPTION
## Summary

Adds two skills from [TasteRay](https://github.com/tasteray/skills) to the **Data & Analysis** section:

- **[elicitation](https://github.com/tasteray/skills/tree/main/elicitation)** - Psychological profiling through natural conversation. Uses research-backed techniques from narrative identity theory and Motivational Interviewing to understand users' preferences, values, and motivations without explicit questionnaires.
- **[recommendations](https://github.com/tasteray/skills/tree/main/recommendations)** - Personalized recommendations powered by the TasteRay API. Covers movies, restaurants, products, travel destinations, and jobs, leveraging psychological profiles built through the elicitation skill.

## Test plan

- [x] Verify both links resolve to valid skill directories
- [x] Entries are placed in the correct section (📊 Data & Analysis)
- [x] Formatting matches existing list entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)