### PR TITLE
Add Apple HIG Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 
 
 ## 🛠 Development & Code Tools
+- [apple-hig-skills](https://github.com/raintree-technology/apple-hig-skills) - Apple Human Interface Guidelines as 14 agent skills covering platforms, foundations, components, patterns, inputs, and technologies for iOS, macOS, visionOS, watchOS, and tvOS.
 - [web-artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.


### PR DESCRIPTION
Adds [apple-hig-skills](https://github.com/raintree-technology/apple-hig-skills) — 14 agent skills providing Apple Human Interface Guidelines for iOS, macOS, visionOS, watchOS, and tvOS design decisions. Covers platforms, foundations, components, patterns, inputs, and technologies.