### PR TITLE
Add Digital Samba Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Skills for working with complex file formats:
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
+| **[digital-samba-skill](https://github.com/digitalsamba/digital-samba-skill)** | Claude Code skill for building video conferencing integrations with Digital Samba, providing API reference, SDK methods, integration patterns, and JWT token guides |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |


### PR DESCRIPTION
## Summary

Adds [digital-samba-skill](https://github.com/digitalsamba/digital-samba-skill) to the **Collaboration & Project Management** section.

**Digital Samba Skill** is a Claude Code skill for building video conferencing integrations with Digital Samba. It provides:

- REST API reference (generated from the OpenAPI spec)
- Embedded SDK methods, events, and properties
- Integration patterns including iframe sizing and embedding
- JWT token authentication guides

This fits the Collaboration & Project Management category because it enables developers to integrate real-time video conferencing into their applications — a core collaboration capability.

The entry follows the existing format: `- [name](url) - Description.`