### PR TITLE
Add Claude Code Video Toolkit to Media & Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@
 - [elevenlabs](https://github.com/sanjay3290/ai-skills/tree/main/skills/elevenlabs) - Text-to-speech narration and two-host podcast generation from documents using ElevenLabs API.
 - [claude-epub-skill](https://github.com/smerchek/claude-epub-skill) - Convert markdown documents, chat summaries, or research reports into a downloadable epub file that can be sent to Kindle.
 - [video-prompting-skill](https://github.com/Square-Zero-Labs/video-prompting-skill) - Draft and refine prompts for video generation models (LTX-2, Sora, Veo 3, etc.) 
+- [Claude Code Video Toolkit](https://github.com/digitalsamba/claude-code-video-toolkit) — AI-native video production workspace for Claude Code with Remotion, ElevenLabs, FFmpeg, and Playwright skills.
 
 
 ## 🏥 Health & Life Sciences


### PR DESCRIPTION
## Summary

Adds [Claude Code Video Toolkit](https://github.com/digitalsamba/claude-code-video-toolkit) to the **Media & Content** section.

## Why Media & Content?

This toolkit is an AI-native video production workspace purpose-built for Claude Code. It bundles multiple skills and tools that cover the full video creation pipeline:

- **Remotion** — React-based programmatic video composition and rendering
- **ElevenLabs** — AI voiceover generation, voice cloning, music, and sound effects
- **FFmpeg** — Asset conversion, compression, and video processing
- **Playwright** — Automated browser demo recording for product videos
- **Qwen-Edit** — AI image editing via cloud GPU (RunPod)

It also includes project templates (sprint review, product demo), brand profile management, scene transitions, shared components, and a multi-session project lifecycle tracked in `project.json`.

The toolkit fits naturally alongside the existing Media & Content entries (video-downloader, elevenlabs, video-prompting-skill, etc.) as it extends Claude Code's capabilities into end-to-end video production.