### PR TITLE
Add doc2md - PDF/DOCX/PPTX to Markdown conversion pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 - [pptx](https://github.com/anthropics/skills/tree/main/skills/pptx) - Read, generate, and adjust slides, layouts, templates.  
 - [xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
 - [revealjs-skill](https://github.com/ryanbbrown/revealjs-skill/tree/main) - Generate polished, professional presentations using the Reveal.js HTML presentation framework.
+- [doc2md](https://github.com/orangefineblue/doc2md) - High-fidelity PDF/DOCX/PPTX to Markdown conversion pipeline with multi-stage QC, per-image classification using 8 heuristics, multi-extractor support (pymupdf, pdfplumber, MinerU), and Claude Code integration via PreToolUse hook and conversion skill.
 
 
 


### PR DESCRIPTION
## What is doc2md?

doc2md is a 15,000-line Python pipeline for high-fidelity PDF/DOCX/PPTX to Markdown conversion, designed specifically for LLM workflows where direct PDF reading is blocked or unreliable.

### Key features

- **Multi-extractor support**: pymupdf4llm (default), pdfplumber (cross-validation), MinerU (complex layouts)
- **Per-image classification**: 8 heuristics classify images as substantive or decorative
- **Multi-stage QC**: Structural QC, content fidelity checks, loop-until-zero-issues
- **Claude Code integration**: PreToolUse hook intercepts PDF/DOCX/PPTX reads and redirects to converted Markdown, plus a conversion SKILL.md

### Category

Document Skills — it converts documents to Markdown and integrates with Claude Code as a skill.

### Links

- Repository: https://github.com/orangefineblue/doc2md
- License: MIT