### PR TITLE
Add email-html-mjml: responsive HTML email templates via MJML 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 - [jules](https://github.com/sanjay3290/ai-skills/tree/main/skills/jules) - Delegate coding tasks to Google Jules AI agent for async bug fixes, documentation, tests, and feature implementation on GitHub repos.
 - [hashicorp-agent-skills](https://github.com/hashicorp/agent-skills) - HashiCorp-maintained Claude skills for Terraform workflows and infrastructure automation.
 - [agnix](https://github.com/avifenesh/agnix) - Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP configs, and more with 156 rules, auto-fix, and LSP server for real-time editor diagnostics.
+- [email-html-mjml](https://github.com/framix-team/skill-email-html-mjml) - Generate responsive HTML email templates using MJML 4.x — cross-client compatible HTML with compilation, validation, width math, and component architecture.
 
 
 


### PR DESCRIPTION
## What this adds

- **[email-html-mjml](https://github.com/framix-team/skill-email-html-mjml)** under **🛠 Development & Code Tools**

## Description

A Claude Code skill that generates responsive HTML email templates using the MJML 4.x framework. Claude automatically handles the full workflow: writing valid MJML, compiling to cross-client compatible HTML via `npx mjml`, validating output, and recovering from compilation errors.

**Key capabilities:**
- Generates MJML templates for welcome emails, newsletters, transactional emails, and promotional campaigns
- Handles width math, column layout, and component architecture
- Compiles to HTML that renders correctly across Gmail, Outlook, Apple Mail, and major clients
- Progressive disclosure: component reference files loaded on-demand to keep token usage minimal

**Install:**
```bash
git clone https://github.com/framix-team/skill-email-html-mjml
cp -r skill-email-html-mjml/email-html-mjml ~/.claude/skills/
```