### PR TITLE
Add LightCMS to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
 - [jules](https://github.com/sanjay3290/ai-skills/tree/main/skills/jules) - Delegate coding tasks to Google Jules AI agent for async bug fixes, documentation, tests, and feature implementation on GitHub repos.
 - [hashicorp-agent-skills](https://github.com/hashicorp/agent-skills) - HashiCorp-maintained Claude skills for Terraform workflows and infrastructure automation.
 - [agnix](https://github.com/avifenesh/agnix) - Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP configs, and more with 156 rules, auto-fix, and LSP server for real-time editor diagnostics.
+- [LightCMS](https://github.com/jonradoff/lightcms) - AI-native CMS with 41 MCP tools for managing websites through natural language. Create pages, templates, assets, themes, collections, redirects, and more with full content versioning.
 
 
 


### PR DESCRIPTION
## Summary
- Adds [LightCMS](https://github.com/jonradoff/lightcms) to the Development & Code Tools section
- AI-native CMS with 41 MCP tools for managing websites through natural language (pages, templates, assets, themes, collections, redirects, content versioning)

## Checklist
- [x] Follows existing list entry format
- [x] Entry placed in the appropriate section (Development & Code Tools)
- [x] Repository link is valid