### PR TITLE
Add AgentWard to Security & Web Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@
 
 ## 🛡 Security & Web Testing
 - [VibeSec-Skill](https://github.com/BehiSecc/VibeSec-Skill) - VibeSec helps Claude write secure code and prevent common vulnerabilities.
-- [AgentWard](https://github.com/agentward-ai/agentward) - Open-source permission control plane for AI agents — scans, enforces, and audits every tool call in code, not prompts.
+- [AgentWard](https://github.com/agentward-ai/agentward) - Open-source runtime & compile-time enforcement layer for AI agents — scans, enforces, and audits every tool call in code, not prompts.
 - [defense-in-depth](https://github.com/obra/superpowers/blob/main/skills/defense-in-depth) - Implement multi-layered testing and security best practices.
 - [ffuf_claude_skill](https://github.com/jthack/ffuf_claude_skill) - Integrate Claude with FFUF (fuzzing) and analyze results for vulnerabilities.
 - [owasp-security](https://github.com/agamm/claude-code-owasp) - OWASP Top 10:2025, ASVS 5.0, and Agentic AI security (2026) with code review checklists, secure patterns, and language-specific quirks for 20+ languages.


### PR DESCRIPTION
Adds [AgentWard](https://github.com/agentward-ai/agentward) — open-source permission control plane for AI agents.

Scans MCP servers, OpenClaw skills, and Python SDK tools, then enforces least-privilege policies at runtime in code (not prompts). Apache 2.0.

- `pip install agentward`
- [GitHub repo](https://github.com/agentward-ai/agentward)