### PR TITLE
Add OpenPaw to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@
 - [@clawfu/mcp-skills](https://github.com/guia-matthieu/clawfu-skills) - 169 expert-sourced marketing skills (Dunford, Schwartz, Ogilvy, Cialdini) as MCP server with brand memory.
 - [wondelai/skills](https://github.com/wondelai/skills) - 25 agent skills for UX design, marketing/CRO, sales, product strategy, and growth based on books by Norman, Cialdini, Ries, Hormozi, and others.
 - [find-skills](https://github.com/agentbay-ai/agentbay-skills) - Helps users discover, search and install agent skills from the marketplace.
+- [OpenPaw](https://github.com/daxaur/openpaw) - 38-skill bundle that turns Claude Code into a personal assistant. Includes git, Telegram, Discord, Obsidian, daily briefing, and more. Run via `npx pawmode`.
 
 ## 🤝 Contribution
 


### PR DESCRIPTION
Adding [OpenPaw](https://github.com/daxaur/openpaw) to the Collections section.

OpenPaw is a 38-skill bundle that turns Claude Code into a personal assistant. Includes git, Telegram, Discord, Obsidian, daily briefing, and more. Run via `npx pawmode`. No daemon, no cloud, MIT licensed.

- **Repo:** https://github.com/daxaur/openpaw
- **npm:** https://www.npmjs.com/package/pawmode