### PR TITLE
Add Playwright Skill by TestDino

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 - [hashicorp-agent-skills](https://github.com/hashicorp/agent-skills) - HashiCorp-maintained Claude skills for Terraform workflows and infrastructure automation.
 - [agnix](https://github.com/avifenesh/agnix) - Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP configs, and more with 156 rules, auto-fix, and LSP server for real-time editor diagnostics.
 - [email-html-mjml](https://github.com/framix-team/skill-email-html-mjml) - Generate responsive HTML email templates using MJML 4.x — cross-client compatible HTML with compilation, validation, width math, and component architecture.
-
+- [Playwright Skill](https://github.com/testdino-hq/playwright-skill) - AI agent-ready Playwright skill with structured SKILL.md, test automation workflows, and MCP-compatible setup for real-world testing pipelines.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
What was added
Added the TestDino Playwright Skill repository, designed for AI agents and Claude-based workflows. The skill provides a structured SKILL.md, automation patterns, and MCP-ready configuration to help agents generate, organize, and report Playwright tests effectively.

Where it was added
Included under the appropriate tools or skills section in the README to align with other AI agent skill repositories.

Notes on usage
This skill is designed for AI agent environments and supports structured test generation workflows, scalable Playwright project patterns, and MCP-compatible configurations. It can be used to standardize Playwright automation setups and integrate AI-assisted testing into CI pipelines.