### PR TITLE
Add LinkedIn automation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@
 - [agentfund-mcp](https://github.com/RioTheGreat-ai/agentfund-mcp) - Crowdfunding for AI agents. Milestone-based escrow on Base chain for proposals, project tracking, and payments.
 - [task-observer](https://github.com/rebelytics/one-skill-to-rule-them-all) - A meta-skill that builds and improves all your skills, including itself.
 - [glitternetwork/pinme](https://github.com/glitternetwork/skills/tree/main/pinme) - PinMe is a zero-config frontend deployment tool. No servers. No accounts. No setup.
+- [linkedin](https://github.com/Linked-API/linkedin-skills) - General-purpose LinkedIn automation via Linked API — fetch profiles, search people/companies, send messages, manage connections, create posts. Supports Sales Navigator.
 
 ## 📰 Articles & Blog Posts 
 


### PR DESCRIPTION
Adding [LinkedIn skill](https://github.com/Linked-API/linkedin-skills) to the Utility & Automation section.

General-purpose LinkedIn automation via [Linked API](https://linkedapi.io) — fetch profiles, search people/companies, send messages, manage connections, create posts, react, comment. Supports Sales Navigator and custom workflows.

- **GitHub**: https://github.com/Linked-API/linkedin-skills