### PR TITLE
Add defi-mcp — DeFi MCP server for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@
 - [mysql](https://github.com/sanjay3290/ai-skills/tree/main/skills/mysql) - Safe read-only SQL queries against MySQL databases.
 - [mssql](https://github.com/sanjay3290/ai-skills/tree/main/skills/mssql) - Safe read-only SQL queries against Microsoft SQL Server databases.
 - [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection.
+- [defi-mcp](https://github.com/OzorOwn/defi-mcp) - DeFi MCP server for Claude Code: real-time crypto prices, multi-chain wallet balances (9 chains), DEX quotes via Jupiter and Li.Fi, and token search across 275+ assets.
 - [octav-api-skill](https://github.com/Octav-Labs/octav-api-skill) - Query Octav's crypto portfolio API: wallet balances, transaction history, DeFi protocol positions, and token analytics across 20+ chains.
 - [elicitation](https://github.com/tasteray/skills/tree/main/elicitation) - Psychological profiling through natural conversation using narrative identity and Motivational Interviewing techniques.
 - [recommendations](https://github.com/tasteray/skills/tree/main/recommendations) - Personalized recommendations across movies, restaurants, products, travel, and jobs via the TasteRay API.


### PR DESCRIPTION
Adds [defi-mcp](https://github.com/OzorOwn/defi-mcp) to the Data & Analysis section.

**What it does:**
- MCP server that gives Claude Code access to real-time DeFi data
- 12 tools: crypto prices, multi-chain wallet balances (ETH, SOL, Base, Polygon, Arbitrum, Optimism, Avalanche, BSC, Fantom), DEX quotes via Jupiter and Li.Fi, token search across 275+ assets
- Works with Claude Desktop and Cursor via standard MCP configuration
- Also available as a hosted REST API

**Category:** Data & Analysis (placed alphabetically before octav-api-skill)