### PR TITLE
docs: add devmarketing-skills to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@
 ## 🗂️ Collections
 - [@clawfu/mcp-skills](https://github.com/guia-matthieu/clawfu-skills) - 169 expert-sourced marketing skills (Dunford, Schwartz, Ogilvy, Cialdini) as MCP server with brand memory.
 - [wondelai/skills](https://github.com/wondelai/skills) - 25 agent skills for UX design, marketing/CRO, sales, product strategy, and growth based on books by Norman, Cialdini, Ries, Hormozi, and others.
+- [devmarketing-skills](https://github.com/jonathimer/devmarketing-skills) - 33 skills for developer marketing — HN strategy, technical tutorials, docs-as-marketing, Reddit engagement, developer onboarding, newsletters, and SEO for devtools.
 - [find-skills](https://github.com/agentbay-ai/agentbay-skills) - Helps users discover, search and install agent skills from the marketplace.
 
 ## 🤝 Contribution


### PR DESCRIPTION
## Summary

Adding [jonathimer/devmarketing-skills](https://github.com/jonathimer/devmarketing-skills) to the Collections section.

**What it is:** 33 AI agent skills specifically for marketing to developers — who skip landing pages, go straight to docs, and read HN comments before signing up.

**Skills include:**
- Hacker News strategy (what works vs what gets flagged)
- Technical tutorials
- Docs-as-marketing
- Reddit engagement
- Developer onboarding
- Developer newsletters
- SEO for devtools
- Community building
- Competitor tracking
- And more

**License:** MIT

**Install:** `npx add-skill jonathimer/devmarketing-skills`

Works with Claude Code, Cursor, Windsurf.