### PR TITLE
Add newsmcp to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@
 - [elicitation](https://github.com/tasteray/skills/tree/main/elicitation) - Psychological profiling through natural conversation using narrative identity and Motivational Interviewing techniques.
 - [recommendations](https://github.com/tasteray/skills/tree/main/recommendations) - Personalized recommendations across movies, restaurants, products, travel, and jobs via the TasteRay API.
 - [x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data extraction for AI coding agents: tweet search, user lookup, followers, engagement metrics, giveaway draws & trending topics.
+- [newsmcp](https://github.com/pranciskus/newsmcp) - Real-time news MCP server for AI agents: news events clustered from hundreds of sources, classified by 12 topics and 30+ regions, with search and detail tools. Free, no API key needed.
 
 
 


### PR DESCRIPTION
## Summary

- Adds [newsmcp](https://github.com/pranciskus/newsmcp) to the **Data & Analysis** section
- newsmcp is a real-time news MCP server for AI agents that aggregates and clusters news events from hundreds of sources
- Classified by 12 topics and 30+ geographic regions, ranked by importance
- Free to use, no API key required — install with `npx -y @newsmcp/server`
- Provides 4 MCP tools: `get_news`, `get_news_detail`, `get_topics`, `search_news`

Website: https://newsmcp.io