### PR TITLE
Add dna-claude-analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@
 
 ## 🏥 Health & Life Sciences
 - [claude-ally-health](https://github.com/huifer/Claude-Ally-Health) - A comprehensive health assistant for Claude to analyze medical reports, track health metrics, and provide personalized wellness suggestions.
+- [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) - Personal genome analysis toolkit that processes raw DNA data from 23andMe/AncestryDNA across 17 categories (health, ancestry, nutrition, pharmacogenomics, longevity, etc.) and generates a terminal-style HTML dashboard.
 
 
 ## 🤝 Collaboration & Project Management


### PR DESCRIPTION
Adding [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) to the Health & Life Sciences section.

Personal genome analysis toolkit that processes raw DNA data from 23andMe/AncestryDNA across 17 categories and generates a terminal-style HTML dashboard.