### PR TITLE
Add avoid-ai-writing to Writing & Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
 - [internal-comms](https://github.com/anthropics/skills/tree/main/skills/internal-comms) - Create internal communications (status reports, leadership updates, 3P updates, company newsletters, FAQs, incident reports, project updates, etc)
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
+- [avoid-ai-writing](https://github.com/conorbronsdon/avoid-ai-writing) - Audits and rewrites content to remove 21 categories of AI writing patterns with a 43-entry replacement table and two-pass detection.
 
 
 ## 📘 Learning & Knowledge  


### PR DESCRIPTION
Adds avoid-ai-writing, a Claude Code skill that detects and fixes 21 categories of AI writing patterns (em dash overuse, copula avoidance, significance inflation, synonym cycling, filler phrases, etc.). Includes a 43-entry word replacement table and a structured four-section output with a second-pass audit. MIT licensed.