### PR TITLE
Add agentskill.sh to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@
 - [devmarketing-skills](https://github.com/jonathimer/devmarketing-skills) - 33 skills for developer marketing — HN strategy, technical tutorials, docs-as-marketing, Reddit engagement, developer onboarding, newsletters, and SEO for devtools.
 - [find-skills](https://github.com/agentbay-ai/agentbay-skills) - Helps users discover, search and install agent skills from the marketplace.
 - [OpenPaw](https://github.com/daxaur/openpaw) - 38-skill bundle that turns Claude Code into a personal assistant. Includes git, Telegram, Discord, Obsidian, daily briefing, and more. Run via `npx pawmode`.
+- [agentskill.sh](https://agentskill.sh) - Browse and install 69,000+ AI agent skills for Claude Code, Cursor, Copilot, Windsurf, Zed, and 20+ AI tools.
 
 ## 🤝 Contribution
 


### PR DESCRIPTION
Adds [agentskill.sh](https://agentskill.sh) to the Collections section.

agentskill.sh is a cross-platform AI agent skills directory with 69,000+ indexed skills for Claude Code, Cursor, Copilot, Windsurf, Zed, and 20+ other AI tools.