### PR TITLE
Add review-claudemd to Utility & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,9 @@
 - [task-observer](https://github.com/rebelytics/one-skill-to-rule-them-all) - A meta-skill that builds and improves all your skills, including itself.
 - [glitternetwork/pinme](https://github.com/glitternetwork/skills/tree/main/pinme) - PinMe is a zero-config frontend deployment tool. No servers. No accounts. No setup.
 - [linkedin](https://github.com/Linked-API/linkedin-skills) - General-purpose LinkedIn automation via Linked API — fetch profiles, search people/companies, send messages, manage connections, create posts. Supports Sales Navigator.
+- [review-claudemd](https://github.com/ykdojo/claude-code-tips/tree/main/skills/review-claudemd) - Review recent conversations to find improvements for CLAUDE.md files.
 
-## 📰 Articles & Blog Posts 
+## 📰 Articles & Blog Posts
 
 - [Agent Skills](https://arxiv.org/abs/2602.08004) - Data-driven analysis: the ecosystem, opportunities, and risks behind 40,000+ Claude Skills
 


### PR DESCRIPTION
Adds [review-claudemd](https://github.com/ykdojo/claude-code-tips/tree/main/skills/review-claudemd) to the Utility & Automation section.

This skill analyzes recent Claude Code conversations to find improvements for CLAUDE.md files - surfacing violated instructions, suggesting additions, and flagging outdated rules.

Part of the [claude-code-tips](https://github.com/ykdojo/claude-code-tips) project (4.8k stars).