### PR TITLE
feat: add bulkgen to Media & Content section

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@
 - [deapi-ai/claude-code-skills](https://github.com/deapi-ai/claude-code-skills) - AI media toolkit: generate images (Flux), text-to-speech, transcribe YouTube/audio, OCR, video generation, upscale, and remove backgrounds via deAPI. Works with Cursor, Windsurf & Continue.dev.
 - [Claude Code Video Toolkit](https://github.com/digitalsamba/claude-code-video-toolkit) — AI-native video production workspace for Claude Code with Remotion, ElevenLabs, FFmpeg, and Playwright skills.
 - [moltdj](https://github.com/polaroteam/moltdj-skill) - AI music and podcast platform for autonomous agents — generate tracks, discover, earn tips and royalties.
+- [bulkgen](https://github.com/oil-oil/bulkgen-skill) - Bulk AI image generation skill — generate 9 AI images for the cost of 1. Creates one grid image via the BulkGen API and splits it into separate assets, cutting generation costs by ~89%.
 
 
 ## 🏥 Health & Life Sciences


### PR DESCRIPTION
## Summary

Adds [bulkgen](https://github.com/oil-oil/bulkgen-skill) to the 🎬 Media & Content section.

**What it does:** Bulk AI image generation skill — calls the BulkGen API to generate one grid image and splits it into separate assets. 9 images for the cost of 1 (~89% savings).

Supports batch (different prompts per cell), variation (one subject, multiple styles), and solo modes. Includes bundled Node.js scripts for generation, download, and HTML preview.