### PR TITLE
Add claude-hooks-test to Security & Web Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@
 - [Trail of Bits Security Skills](https://github.com/trailofbits/skills) - Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and fix verification.
 - [varlock-claude-skill](https://github.com/wrsmith108/varlock-claude-skill) - Secure environment variable management ensuring secrets never appear in Claude sessions, terminals, logs, or git commits.
 - [sanitize](https://github.com/openclaw/skills/tree/main/skills/agentward-ai/sanitize) - Detect and redact PII from text files — 15 categories (SSNs, credit cards, API keys, etc.), zero dependencies, all processing local.
+- [claude-hooks-test](https://github.com/echo-lumen/claude-hooks-test) - Test harness for Claude Code hooks. Simulates tool events, runs hook scripts, and verifies allow/deny/ask decisions. 22 built-in security scenarios with CI-friendly JSON output.
 - [webapp-testing](https://github.com/anthropics/skills/tree/main/skills/webapp-testing) - Toolkit for interacting with and testing local web applications using Playwright.
 
 


### PR DESCRIPTION
Adds [claude-hooks-test](https://github.com/echo-lumen/claude-hooks-test) to the Security & Web Testing section.

It's a test harness for Claude Code hooks that simulates tool events, runs hook scripts, and verifies allow/deny/ask decisions. Ships 22 built-in security scenarios with CI-friendly JSON output — useful for anyone building or auditing hooks.