### PR TITLE
Add claude-code-memory to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 - [lightning-channel-factories](https://github.com/8144225309/superscalar-mcp/tree/master/skills/lightning-channel-factories) - Technical reference on Lightning Network channel factories, multi-party channels, LSP architectures, and Bitcoin Layer 2 scaling without soft forks.
 - [lightning-architecture-review](https://github.com/8144225309/superscalar-mcp/tree/master/skills/lightning-architecture-review) - Review Bitcoin Lightning Network protocol designs, compare channel factory approaches, and analyze Layer 2 scaling tradeoffs.
 - [Playwright Skill](https://github.com/testdino-hq/playwright-skill) - AI agent-ready Playwright skill with structured SKILL.md, test automation workflows, and MCP-compatible setup for real-world testing pipelines.
+- [claude-code-memory](https://github.com/echo-lumen/claude-code-memory) - Observational memory for Claude Code — a PostToolUse hook that records tool interactions and consolidates them into structured project knowledge. Zero dependencies, rule-based consolidation.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
Adds [claude-code-memory](https://github.com/echo-lumen/claude-code-memory) to the Development & Code Tools section.

A PostToolUse hook that records tool interactions and consolidates them into structured project knowledge (files by interaction count, common searches, command frequency, session summaries). Zero dependencies, rule-based consolidation. 31 tests.