### PR TITLE
Add Agent Almanac - 299 skills collection for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@
 - [find-skills](https://github.com/agentbay-ai/agentbay-skills) - Helps users discover, search and install agent skills from the marketplace.
 - [OpenPaw](https://github.com/daxaur/openpaw) - 38-skill bundle that turns Claude Code into a personal assistant. Includes git, Telegram, Discord, Obsidian, daily briefing, and more. Run via `npx pawmode`.
 - [agentskill.sh](https://agentskill.sh) - Browse and install 69,000+ AI agent skills for Claude Code, Cursor, Copilot, Windsurf, Zed, and 20+ AI tools.
+- [Agent Almanac](https://github.com/pjt222/agent-almanac) - 317 skills, 65 agents, and 14 teams for Claude Code following the Agent Skills open standard across 50+ domains.
 
 ## 🤝 Contribution
 


### PR DESCRIPTION
## Summary

- Adds [Agent Almanac](https://github.com/pjt222/agent-almanac) to the Collections section
- 299 skills, 62 agents, and 12 teams for Claude Code across 50+ domains (R packages, DevOps, security, scientific research, and more)
- Follows the [Agent Skills open standard](https://agentskills.io)
- All skills use the standard SKILL.md format with frontmatter, procedures, validation, and error handling
- Agents and teams compose skills into personas and multi-agent workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)