### PR TITLE
Add claude-ecom to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@
 - [elicitation](https://github.com/tasteray/skills/tree/main/elicitation) - Psychological profiling through natural conversation using narrative identity and Motivational Interviewing techniques.
 - [recommendations](https://github.com/tasteray/skills/tree/main/recommendations) - Personalized recommendations across movies, restaurants, products, travel, and jobs via the TasteRay API.
 - [x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data extraction for AI coding agents: tweet search, user lookup, followers, engagement metrics, giveaway draws & trending topics.
-- [claude-ecom](https://github.com/takechanman1228/claude-ecom) - Converts ecommerce order/sales CSV into a business review with 8 KPI trees, 30/90/365-day multi-horizon analysis, prioritized findings, and an action plan.
+- [claude-ecom](https://github.com/takechanman1228/claude-ecom) - Generate full ecommerce business reviews from order CSVs — KPIs, diagnostics, and action plans.
 
 
 


### PR DESCRIPTION
## Summary

Adding [claude-ecom](https://github.com/takechanman1228/claude-ecom) to the Data & Analysis section.

Claude Code skill that converts ecommerce order or sales CSV files into a consultant-style business review (`REVIEW.md`).

**What it generates:**
- Executive summary with narrative analysis
- Multi-horizon dashboard (30 d / 90 d / 365 d)
- 8 KPI trees with 🔴/🟢 health signals (Revenue, Orders, AOV, Customers, Repeat Rate, etc.)
- Prioritized findings in "what / why / what to do" format
- Action plan with deadlines, success metrics, and guardrails

**Install:**
```
curl -fsSL https://raw.githubusercontent.com/takechanman1228/claude-ecom/v0.1.3/install.sh | bash
```

Or via plugin:
```
/plugin marketplace add takechanman1228/claude-ecom
/plugin install claude-ecom@claude-ecom
/reload-plugins
```

**License:** MIT