### PR TITLE
Add PUA skill — corporate motivation engine for AI agents (CN/EN/JP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@
 ## 🔧 Utility & Automation  
 - [file-organizer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/file-organizer) - Intelligently organizes your files and folders across your computer.
 - [invoice-organizer](https://github.com/ComposioHQ/awesome-claude-skills/blob/master/invoice-organizer/SKILL.md) - Automatically organizes invoices and receipts for tax preparation
+- [pua](https://github.com/tanweai/pua) - Forces AI agents to exhaust all solutions before giving up, using culturally authentic corporate motivation in three editions: Chinese PUA (Alibaba 361), English PIP (Amazon/Google calibration), Japanese 詰め (Toyota 改善/Dentsu 鬼十則). Cross-platform: Claude Code, Codex, Gemini CLI, Cursor, Windsurf.
 - [skill-creator](https://github.com/anthropics/skills/tree/main/skills/skill-creator) - Template / helper to build new Claude skills.  
 - [template-skill](https://github.com/anthropics/skills/tree/main/template) - Minimal skeleton for a new skill project structure.
 - [agentfund-mcp](https://github.com/RioTheGreat-ai/agentfund-mcp) - Crowdfunding for AI agents. Milestone-based escrow on Base chain for proposals, project tracking, and payments.


### PR DESCRIPTION
## Add PUA Skill

**Repository:** [tanweai/pua](https://github.com/tanweai/pua)
**Section:** 🔧 Utility & Automation
**Stars:** 6,900+ | **Forks:** 310+

### What it does

PUA forces AI agents to exhaust all possible solutions before giving up. Instead of saying "I can't do this" or "please do it manually", the agent is pushed to try harder with structured debugging methodology and escalating pressure.

### Three culturally authentic editions

| Edition | Culture | Key Elements |
|---------|---------|-------------|
| **Chinese (PUA 味)** | Alibaba 361 reviews | 灵魂拷问, 双重束缚, 361考核, wolf culture |
| **English (PIP Edition)** | Amazon/Google calibration | PIP, Keeper Test, stack ranking, calibration committee |
| **Japanese (詰め Edition)** | Toyota/Dentsu | 改善, 鬼十則, 圧倒的当事者意識, なぜなぜ5回 |

### Cross-platform support

Works with Claude Code, Codex CLI, Gemini CLI, Cursor, and Windsurf.

### Why it belongs in Utility & Automation

It's a general-purpose agent behavior modifier — not domain-specific. It makes any AI agent more persistent and thorough regardless of the task type (debugging, research, writing, deployment, etc.).