### PR TITLE
Add ShellWard security-guide to Security & Web Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@
 - [defense-in-depth](https://github.com/obra/superpowers/blob/main/skills/defense-in-depth) - Implement multi-layered testing and security best practices.
 - [ffuf_claude_skill](https://github.com/jthack/ffuf_claude_skill) - Integrate Claude with FFUF (fuzzing) and analyze results for vulnerabilities.
 - [owasp-security](https://github.com/agamm/claude-code-owasp) - OWASP Top 10:2025, ASVS 5.0, and Agentic AI security (2026) with code review checklists, secure patterns, and language-specific quirks for 20+ languages.
+- [shellward-security-guide](https://github.com/jnMetaCode/shellward/tree/main/skills/security-guide) - AI agent security middleware with 8-layer defense — prompt injection detection, DLP data flow tracking, dangerous command blocking, PII scanning. `npx clawhub install shellward-security-guide`
 - [systematic-debugging](https://github.com/obra/superpowers/blob/main/skills/systematic-debugging) - Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes
 - [Trail of Bits Security Skills](https://github.com/trailofbits/skills) - Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and fix verification.
 - [varlock-claude-skill](https://github.com/wrsmith108/varlock-claude-skill) - Secure environment variable management ensuring secrets never appear in Claude sessions, terminals, logs, or git commits.


### PR DESCRIPTION
Adding ShellWard's security-guide skill to the Security & Web Testing section.

8-layer AI agent security defense:
- Prompt injection detection (32 rules)
- DLP-style data flow tracking
- Dangerous command blocking
- PII/API key detection

Install: `npx clawhub install shellward-security-guide`
GitHub: https://github.com/jnMetaCode/shellward