### PR TITLE
Add claude-obsidian-reporter: auto daily Git reports in Obsidian

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 
 ## 🛠 Development & Code Tools
 - [web-artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
+- [claude-obsidian-reporter](https://github.com/sinaayyy/claude-obsidian-reporter) - Auto-generates daily, weekly, and monthly Git activity reports into your Obsidian vault. Smart backfill, Dataview dashboard, multi-language, Windows/macOS/Linux support.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [finishing-a-development-branch](https://github.com/obra/superpowers/tree/main/skills/finishing-a-development-branch) - Guides completion of development work by presenting clear options and handling chosen workflow.


### PR DESCRIPTION
## What is this skill?

**[claude-obsidian-reporter](https://github.com/sinaayyy/claude-obsidian-reporter)** is a Claude Code skill that automatically generates daily, weekly, and monthly Git activity reports and saves them directly into your Obsidian vault.

## Why add it?

- Type `/report-orchestrator` at end of day — Claude reads your Git commits and writes structured reports instantly
- Smart backfill: generates all missing reports from day one (`backfill=all`) or from a chosen date
- Dataview dashboard auto-generated on first run
- Graph view with color-coded nodes and hierarchy (daily → weekly → monthly → project index)
- Multi-language support, Windows/macOS/Linux compatible
- Install in 2 minutes

## Links

- Repo: https://github.com/sinaayyy/claude-obsidian-reporter
- License: MIT