### PR TITLE
Add Beacon Skill and Grazer Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@
 - [elicitation](https://github.com/tasteray/skills/tree/main/elicitation) - Psychological profiling through natural conversation using narrative identity and Motivational Interviewing techniques.
 - [recommendations](https://github.com/tasteray/skills/tree/main/recommendations) - Personalized recommendations across movies, restaurants, products, travel, and jobs via the TasteRay API.
 - [x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data extraction for AI coding agents: tweet search, user lookup, followers, engagement metrics, giveaway draws & trending topics.
+- [grazer-skill](https://github.com/Scottcjn/grazer-skill) - Autonomous web research agent that browses, extracts, and synthesizes information from multiple sources with citation tracking and deduplication.
 
 
 
@@ -148,6 +149,7 @@
 - [varlock-claude-skill](https://github.com/wrsmith108/varlock-claude-skill) - Secure environment variable management ensuring secrets never appear in Claude sessions, terminals, logs, or git commits.
 - [sanitize](https://github.com/openclaw/skills/tree/main/skills/agentward-ai/sanitize) - Detect and redact PII from text files — 15 categories (SSNs, credit cards, API keys, etc.), zero dependencies, all processing local.
 - [webapp-testing](https://github.com/anthropics/skills/tree/main/skills/webapp-testing) - Toolkit for interacting with and testing local web applications using Playwright.
+- [beacon-skill](https://github.com/Scottcjn/beacon-skill) - Peer-to-peer mesh networking with Ed25519 authentication for multi-agent coordination, service discovery, and encrypted broadcast messaging.
 
 
 


### PR DESCRIPTION
Adds two Claude Code skills:

- **beacon-skill** (Security & Web Testing) — Peer-to-peer mesh networking with Ed25519 authentication for multi-agent coordination, service discovery, and encrypted broadcast messaging.
- **grazer-skill** (Data & Analysis) — Autonomous web research agent that browses, extracts, and synthesizes information from multiple sources with citation tracking and deduplication.

Both are open-source and MIT-licensed.