### PR TITLE
Add Prism Scanner — security scanner for agent skills/plugins/MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@
 - [owasp-security](https://github.com/agamm/claude-code-owasp) - OWASP Top 10:2025, ASVS 5.0, and Agentic AI security (2026) with code review checklists, secure patterns, and language-specific quirks for 20+ languages.
 - [systematic-debugging](https://github.com/obra/superpowers/blob/main/skills/systematic-debugging) - Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes
 - [Trail of Bits Security Skills](https://github.com/trailofbits/skills) - Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and fix verification.
+- [Prism Scanner](https://github.com/aidongise-cell/prism-scanner) - Security scanner for AI Agent skills, plugins, and MCP servers. 39+ detection rules with AST taint tracking, malicious signature matching, and A-F grading. `pip install prism-scanner`
 - [varlock-claude-skill](https://github.com/wrsmith108/varlock-claude-skill) - Secure environment variable management ensuring secrets never appear in Claude sessions, terminals, logs, or git commits.
 - [sanitize](https://github.com/openclaw/skills/tree/main/skills/agentward-ai/sanitize) - Detect and redact PII from text files — 15 categories (SSNs, credit cards, API keys, etc.), zero dependencies, all processing local.
 - [webapp-testing](https://github.com/anthropics/skills/tree/main/skills/webapp-testing) - Toolkit for interacting with and testing local web applications using Playwright.


### PR DESCRIPTION
## Summary

Adds [Prism Scanner](https://github.com/aidongise-cell/prism-scanner) to the Security & Web Testing section.

**Prism Scanner** is an open-source (Apache 2.0) security scanner for AI Agent skills, plugins, and MCP servers:
- **39+ detection rules**: AST taint tracking, malicious signatures, metadata analysis, system residue
- **A-F grading** with actionable recommendations
- **Full lifecycle**: pre-install + post-uninstall residue cleanup
- Complements VibeSec and OWASP with agent-specific supply chain security

Install: `pip install prism-scanner` or `npx skills add aidongise-cell/prism-scanner`