### PR TITLE
Add SkillHub - Chinese AI Skill Marketplace (50+ skills, 5000+ index)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@
 - [AlterLab-Academic-Skills](https://github.com/AlterLab-IEU/AlterLab-Academic-Skills) - 186+ academic research skills across 13 domains for higher education and research.
 - [AlterLab_GameForge](https://github.com/AlterLab-IEU/AlterLab_GameForge) - 34 game development skills covering design, mechanics, and production pipelines.
 - [Claude Code SDK](https://github.com/SeifBenayed/claude-code-sdk) - Open-source, provider-agnostic CLI for AI agents. 13 providers, built-in tools, skill marketplace.
+- [SkillHub / 技能宝](https://github.com/kevinaimonster/skill-hub) - 100+ Chinese-first skills (Xiaohongshu, WeChat, code review, etc.) with 5000+ skill index.
 
 
 ## 🤝 Contribution


### PR DESCRIPTION
## What is SkillHub / 技能宝?

Chinese-first AI skill marketplace with:
- 50+ curated skills (20 Chinese-specific originals like Xiaohongshu, Douyin, WeChat)
- 5,000+ skill index covering 13 categories
- 12-layer security scanning
- Support for 42 agent platforms (Claude Code, Cursor, Windsurf, etc.)

Install: `npx skills add kevinaimonster/skill-hub --full-depth --skill '*' -g -y`

GitHub: https://github.com/kevinaimonster/skill-hub