### PR TITLE
Add liepin-jobs skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@
 
 
 ## 🔧 Utility & Automation  
-- [liepin-jobs](https://github.com/xllinbupt/MCP2skill) - Search jobs on Liepin (猎聘), apply to positions, view and edit resumes. Zero-dependency Python CLI wrapping Liepin's official MCP Server.
+- [liepin-cli](https://github.com/liepin-tech-2026/liepin-cil) - Search jobs on Liepin (猎聘), apply to positions, view and edit resumes. Local CLI tool for Liepin job search & resume management.
 - [file-organizer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/file-organizer) - Intelligently organizes your files and folders across your computer.
 - [invoice-organizer](https://github.com/ComposioHQ/awesome-claude-skills/blob/master/invoice-organizer/SKILL.md) - Automatically organizes invoices and receipts for tax preparation
 - [skill-creator](https://github.com/anthropics/skills/tree/main/skills/skill-creator) - Template / helper to build new Claude skills.  

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@
 
 
 ## 🔧 Utility & Automation  
+- [liepin-jobs](https://github.com/xllinbupt/MCP2skill) - Search jobs on Liepin (猎聘), apply to positions, view and edit resumes. Zero-dependency Python CLI wrapping Liepin's official MCP Server.
 - [file-organizer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/file-organizer) - Intelligently organizes your files and folders across your computer.
 - [invoice-organizer](https://github.com/ComposioHQ/awesome-claude-skills/blob/master/invoice-organizer/SKILL.md) - Automatically organizes invoices and receipts for tax preparation
 - [skill-creator](https://github.com/anthropics/skills/tree/main/skills/skill-creator) - Template / helper to build new Claude skills.  


### PR DESCRIPTION
## Summary
- Renames entry from `liepin-jobs` to `liepin-cli`
- Updates source link to [liepin-tech-2026/liepin-cil](https://github.com/liepin-tech-2026/liepin-cil)
- Search jobs on Liepin (猎聘), apply to positions, view and edit resumes
- Local CLI tool powered by `liepin-cli` (Python 3.11+, Typer + Pydantic)