### PR TITLE
Add Reporecall — local codebase memory with hooks + MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
 - [claude-skills](https://github.com/jeffallan/claude-skills) - 65 full-stack development skills with progressive disclosure, covering React, NestJS, Python, DevOps, and 30+ frameworks.
 - [jules](https://github.com/sanjay3290/ai-skills/tree/main/skills/jules) - Delegate coding tasks to Google Jules AI agent for async bug fixes, documentation, tests, and feature implementation on GitHub repos.
 - [hashicorp-agent-skills](https://github.com/hashicorp/agent-skills) - HashiCorp-maintained Claude skills for Terraform workflows and infrastructure automation.
+- [reporecall](https://github.com/proofofwork-agency/reporecall) - Local codebase memory for Claude Code. Indexes with Tree-sitter AST (22 languages), builds call graphs, and injects context via hooks in ~5ms. Reduces token usage by 3-8x. Also works as an MCP server.
 - [agnix](https://github.com/avifenesh/agnix) - Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP configs, and more with 156 rules, auto-fix, and LSP server for real-time editor diagnostics.
 - [email-html-mjml](https://github.com/framix-team/skill-email-html-mjml) - Generate responsive HTML email templates using MJML 4.x — cross-client compatible HTML with compilation, validation, width math, and component architecture.
 - [agent-cards-skill](https://github.com/agent-cards/skill) - Manage prepaid virtual Visa cards for AI agents. Create cards, check balances, view credentials, close cards, and get support via MCP tools.


### PR DESCRIPTION
## What it does

[Reporecall](https://github.com/proofofwork-agency/reporecall) gives Claude Code a codebase memory so it stops wasting tokens rediscovering your code.

**The problem:** Claude Code spends its first moves grepping and reading files to understand a codebase it's already seen. On large repos this burns through context window and token budget before real work starts.

**The solution:** Reporecall pre-indexes your codebase using Tree-sitter AST parsing (22 languages), builds call graphs, and injects relevant context via a hook in ~5ms — before Claude starts thinking. No grep chains, no exploration loops.

- Hybrid keyword + vector search
- Call graph traversal (callers + callees)
- Also works as an MCP server
- 3-8x reduction in token usage for context gathering

npm: `@proofofwork-agency/reporecall`