### PR TITLE
Add privacy-mask skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@
 - [Trail of Bits Security Skills](https://github.com/trailofbits/skills) - Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and fix verification.
 - [varlock-claude-skill](https://github.com/wrsmith108/varlock-claude-skill) - Secure environment variable management ensuring secrets never appear in Claude sessions, terminals, logs, or git commits.
 - [sanitize](https://github.com/openclaw/skills/tree/main/skills/agentward-ai/sanitize) - Detect and redact PII from text files — 15 categories (SSNs, credit cards, API keys, etc.), zero dependencies, all processing local.
+- [privacy-mask](https://github.com/fullstackcrew-alpha/privacy-mask) - Local image privacy masking — detect and redact PII, API keys, and secrets in screenshots via OCR + 47 regex rules before images leave your machine. Claude Code hook for automatic redaction. 100% offline.
 - [webapp-testing](https://github.com/anthropics/skills/tree/main/skills/webapp-testing) - Toolkit for interacting with and testing local web applications using Playwright.
 
 


### PR DESCRIPTION
Adds [privacy-mask](https://github.com/fullstackcrew-alpha/privacy-mask) — local image privacy masking, detect and redact PII in screenshots via OCR + 47 regex rules. Claude Code hook for automatic redaction. 100% offline, MIT licensed.