### PR TITLE
Add vibecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@
 - [Agent Skills](https://arxiv.org/abs/2602.08004) - Data-driven analysis: the ecosystem, opportunities, and risks behind 40,000+ Claude Skills
 
 ## 🗂️ Collections
+- [vibecosystem](https://github.com/vibeeval/vibecosystem) - Complete AI software team for Claude Code with 119 agents, 202 skills, 48 hooks, self-learning pipeline, and cross-project pattern promotion.
 - [@clawfu/mcp-skills](https://github.com/guia-matthieu/clawfu-skills) - 169 expert-sourced marketing skills (Dunford, Schwartz, Ogilvy, Cialdini) as MCP server with brand memory.
 - [wondelai/skills](https://github.com/wondelai/skills) - 25 agent skills for UX design, marketing/CRO, sales, product strategy, and growth based on books by Norman, Cialdini, Ries, Hormozi, and others.
 - [devmarketing-skills](https://github.com/jonathimer/devmarketing-skills) - 33 skills for developer marketing — HN strategy, technical tutorials, docs-as-marketing, Reddit engagement, developer onboarding, newsletters, and SEO for devtools.


### PR DESCRIPTION
Adding vibecosystem — a complete AI software team for Claude Code with 119 agents, 202 skills, 48 hooks, self-learning pipeline, and cross-project pattern promotion.

Repo: https://github.com/vibeeval/vibecosystem
License: MIT