### PR TITLE
Add widemem: Claude Code memory skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 
 
 ## 🛠 Development & Code Tools
+- [widemem](https://github.com/remete618/widemem-skill) - Persistent AI memory skill with semantic search, confidence scoring, and quality gates. Remembers at scale, knows when it doesn't.
 - [web-artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.


### PR DESCRIPTION
Adding [widemem](https://github.com/remete618/widemem-skill), a proper Claude Code skill.

Previously submitted as a memory layer (#122) and correctly rejected. This time it is a real skill with SKILL.md, plugin.json, /mem slash commands, quality gates, and confidence scoring.

Skill repo: https://github.com/remete618/widemem-skill
License: Apache 2.0