### PR TITLE
Add claude-learn to Learning & Knowledge section

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@
 
 
 ## 📘 Learning & Knowledge  
+- [claude-learn](https://github.com/OutcomeFocusAi/claude-learn) - Self-improving behavioral rules for Claude Code. Closed feedback loop with scored rules, automated decay, and collective intelligence via community playbook sharing.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.  
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 


### PR DESCRIPTION
## Summary
- Adds [claude-learn](https://github.com/OutcomeFocusAi/claude-learn) to the **📘 Learning & Knowledge** section
- Self-improving behavioral rules plugin for Claude Code with scored rules, automated decay, and community playbook sharing
- Entry placed alphabetically within the section

## Test plan
- [x] Entry matches existing format (markdown link + dash + description)
- [x] Alphabetical ordering maintained
- [x] No other changes to the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)