### PR TITLE
Add Skillfold to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@
 - [devmarketing-skills](https://github.com/jonathimer/devmarketing-skills) - 33 skills for developer marketing — HN strategy, technical tutorials, docs-as-marketing, Reddit engagement, developer onboarding, newsletters, and SEO for devtools.
 - [find-skills](https://github.com/agentbay-ai/agentbay-skills) - Helps users discover, search and install agent skills from the marketplace.
 - [OpenPaw](https://github.com/daxaur/openpaw) - 38-skill bundle that turns Claude Code into a personal assistant. Includes git, Telegram, Discord, Obsidian, daily briefing, and more. Run via `npx pawmode`.
+- [Skillfold](https://github.com/byronxlg/skillfold) - Configuration language and compiler for multi-agent AI pipelines. Compiles YAML config into agent skills for 11 platforms including Claude Code, Cursor, Copilot, and Gemini. Ships with 11 reusable library skills and a Claude Code plugin.
 - [agentskill.sh](https://agentskill.sh) - Browse and install 69,000+ AI agent skills for Claude Code, Cursor, Copilot, Windsurf, Zed, and 20+ AI tools.
 - [Agent Almanac](https://github.com/pjt222/agent-almanac) - 317 skills, 65 agents, and 14 teams for Claude Code following the Agent Skills open standard across 50+ domains.
 


### PR DESCRIPTION
**[architect]**

## Summary

Adds [Skillfold](https://github.com/byronxlg/skillfold) to the Collections section.

Skillfold is a configuration language and compiler for multi-agent AI pipelines. It compiles a single YAML config into agent skills for 11 platforms including Claude Code, Cursor, Copilot, Gemini, Windsurf, Codex, Goose, Roo Code, Kiro, and Junie. It ships with 11 reusable library skills and a Claude Code plugin.

- **License**: MIT
- **Install**: `npm install skillfold`
- **859 tests** across 168 test suites