### PR TITLE
Add kasetto to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@
 - [wondelai/skills](https://github.com/wondelai/skills) - 25 agent skills for UX design, marketing/CRO, sales, product strategy, and growth based on books by Norman, Cialdini, Ries, Hormozi, and others.
 - [devmarketing-skills](https://github.com/jonathimer/devmarketing-skills) - 33 skills for developer marketing — HN strategy, technical tutorials, docs-as-marketing, Reddit engagement, developer onboarding, newsletters, and SEO for devtools.
 - [find-skills](https://github.com/agentbay-ai/agentbay-skills) - Helps users discover, search and install agent skills from the marketplace.
+- [kasetto](https://github.com/pivoshenko/kasetto) - A declarative AI agent environment manager, written in Rust.
 - [OpenPaw](https://github.com/daxaur/openpaw) - 38-skill bundle that turns Claude Code into a personal assistant. Includes git, Telegram, Discord, Obsidian, daily briefing, and more. Run via `npx pawmode`.
 - [agentskill.sh](https://agentskill.sh) - Browse and install 69,000+ AI agent skills for Claude Code, Cursor, Copilot, Windsurf, Zed, and 20+ AI tools.
 - [Agent Almanac](https://github.com/pjt222/agent-almanac) - 317 skills, 65 agents, and 14 teams for Claude Code following the Agent Skills open standard across 50+ domains.


### PR DESCRIPTION
Hey! 👋

This PR adds [kasetto](https://github.com/pivoshenko/kasetto) to the **Collections** section.

kasetto is a declarative AI skills manager written in Rust. It syncs skills from multiple GitHub repos and local directories into 35+ agent environments using a single YAML config. Think of it as a package manager for AI agent skills.

**Key features:**
- Declarative YAML config — version it, share it across teams
- 35+ built-in agent presets (Claude Code, Cursor, Codex, Windsurf, etc.)
- Local SQLite manifest for tracking installs
- `--dry-run`, `--json`, `--verbose` for CI/scripting

Thank you for reviewing! 🙏