### PR TITLE
Add SkillCheck-Free skill validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@
 - [glitternetwork/pinme](https://github.com/glitternetwork/skills/tree/main/pinme) - PinMe is a zero-config frontend deployment tool. No servers. No accounts. No setup.
 - [linkedin](https://github.com/Linked-API/linkedin-skills) - General-purpose LinkedIn automation via Linked API — fetch profiles, search people/companies, send messages, manage connections, create posts. Supports Sales Navigator.
 - [review-claudemd](https://github.com/ykdojo/claude-code-tips/tree/main/skills/review-claudemd) - Review recent conversations to find improvements for CLAUDE.md files.
+- [SkillCheck-Free](https://github.com/olgasafonova/SkillCheck-Free) - Free SKILL.md validator with 30+ checks across structure, naming, and semantics. Catches common errors before deploying Claude Code skills.
 
 ## 📰 Articles & Blog Posts
 


### PR DESCRIPTION
Adds [SkillCheck-Free](https://github.com/olgasafonova/SkillCheck-Free) to the Utility & Automation section.

- Free SKILL.md validator with 30+ checks across structure, naming, and semantics
- Catches common errors before deploying Claude Code skills
- MIT licensed