### PR TITLE
Add naming skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [avoid-ai-writing](https://github.com/conorbronsdon/avoid-ai-writing) - Audits and rewrites content to remove 21 categories of AI writing patterns with a 43-entry replacement table and two-pass detection.
+- [naming](https://github.com/glacierphonk/naming) - Metaphor-driven naming for products, SaaS, brands, bots, and open source projects. Structured process that produces memorable, meaningful names.
 
 
 ## 📘 Learning & Knowledge  


### PR DESCRIPTION
## Summary

Adds the naming skill under Writing & Research.

A Claude Code skill for naming products, SaaS, brands, bots, and open source projects using a structured metaphor-driven process. MIT licensed, hosted at https://github.com/glacierphonk/naming