### PR TITLE
Add moodtrip-hotel-search — Hotel search & booking skill via MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@
 - [task-observer](https://github.com/rebelytics/one-skill-to-rule-them-all) - A meta-skill that builds and improves all your skills, including itself.
 - [glitternetwork/pinme](https://github.com/glitternetwork/skills/tree/main/pinme) - PinMe is a zero-config frontend deployment tool. No servers. No accounts. No setup.
 - [linkedin](https://github.com/Linked-API/linkedin-skills) - General-purpose LinkedIn automation via Linked API — fetch profiles, search people/companies, send messages, manage connections, create posts. Supports Sales Navigator.
+- [moodtrip-hotel-search](https://github.com/adiny/moodtrip-hotel-search) - Hotel search, comparison, reviews, pricing, and booking handoff via MoodTrip.ai MCP server. 12 tools including semantic search, room matching, and price intelligence.
 - [review-claudemd](https://github.com/ykdojo/claude-code-tips/tree/main/skills/review-claudemd) - Review recent conversations to find improvements for CLAUDE.md files.
 
 ## 📰 Articles & Blog Posts


### PR DESCRIPTION
Adding moodtrip-hotel-search — a skill that enables Claude to search, compare, evaluate, and hand off hotel bookings through the MoodTrip.ai MCP server.

- 12 MCP tools: semantic search, real-time pricing, reviews with AI sentiment analysis, room photo matching, price trends, booking link handoff
- - Works with Claude.ai, Claude Desktop, and ChatGPT via MCP
- - No API key required for search operations
- - Open source (MIT-0)
Repo: https://github.com/adiny/moodtrip-hotel-search
MCP Endpoint: https://api.moodtrip.ai/api/mcp-http