### PR TITLE
Add gh-star-history to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@
 - [x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data extraction for AI coding agents: tweet search, user lookup, followers, engagement metrics, giveaway draws & trending topics.
 - [claude-ecom](https://github.com/takechanman1228/claude-ecom) - Generate full ecommerce business reviews from order CSVs — KPIs, diagnostics, and action plans.
 - [chainaware-behavioral-prediction](https://github.com/ChainAware/behavioral-prediction-mcp) - ChainAware Skill for AI-powered tools to analyze wallet behaviour prediction,fraud detection and rug pull prediction.
+- [gh-star-history](https://github.com/ykdojo/gh-star-history) - Visualize and compare GitHub star history as interactive charts, with regional breakdown of stargazers.
 
 
 ## 🔬 Scientific & Research Tools


### PR DESCRIPTION
Adds [gh-star-history](https://github.com/ykdojo/gh-star-history) - a Claude Code plugin that visualizes GitHub star history as interactive charts with regional breakdown of stargazers.

Features:
- Interactive Plotly charts for star history
- Multi-repo comparison
- Regional breakdown of stargazers by location
- Local caching for fast re-runs