### PR TITLE
Add XVARY Stock Research to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@
 - [OpenPaw](https://github.com/daxaur/openpaw) - 38-skill bundle that turns Claude Code into a personal assistant. Includes git, Telegram, Discord, Obsidian, daily briefing, and more. Run via `npx pawmode`.
 - [agentskill.sh](https://agentskill.sh) - Browse and install 69,000+ AI agent skills for Claude Code, Cursor, Copilot, Windsurf, Zed, and 20+ AI tools.
 - [Agent Almanac](https://github.com/pjt222/agent-almanac) - 317 skills, 65 agents, and 14 teams for Claude Code following the Agent Skills open standard across 50+ domains.
+- [XVARY Stock Research](https://github.com/xvary-research/claude-code-stock-analysis-skill) - Public SEC EDGAR + market data for thesis-driven equity analysis in Claude Code (`/analyze`, `/score`, `/compare`). MIT.
 
 ## 🤝 Contribution
 


### PR DESCRIPTION
Adds [xvary-research/claude-code-stock-analysis-skill](https://github.com/xvary-research/claude-code-stock-analysis-skill) under Collections. MIT; Claude Code / Cursor-compatible SKILL.md workflow for public equity research.

Made with [Cursor](https://cursor.com)