### PR TITLE
Add skills-janitor - skill hygiene plugin (7 commands, zero deps)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@
 
 ## 🔧 Utility & Automation  
 - [file-organizer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/file-organizer) - Intelligently organizes your files and folders across your computer.
+[skills-janitor](https://github.com/khendzel/skills-janitor) - Audit, deduplicate, check, fix, and track usage of your Claude Code skills. 9 actions, zero dependencies.
 - [invoice-organizer](https://github.com/ComposioHQ/awesome-claude-skills/blob/master/invoice-organizer/SKILL.md) - Automatically organizes invoices and receipts for tax preparation
 - [skill-creator](https://github.com/anthropics/skills/tree/main/skills/skill-creator) - Template / helper to build new Claude skills.  
 - [template-skill](https://github.com/anthropics/skills/tree/main/template) - Minimal skeleton for a new skill project structure.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,6 @@
 
 ## 🔧 Utility & Automation  
 - [file-organizer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/file-organizer) - Intelligently organizes your files and folders across your computer.
-[skills-janitor](https://github.com/khendzel/skills-janitor) - Audit, deduplicate, check, fix, and track usage of your Claude Code skills. 9 actions, zero dependencies.
 - [invoice-organizer](https://github.com/ComposioHQ/awesome-claude-skills/blob/master/invoice-organizer/SKILL.md) - Automatically organizes invoices and receipts for tax preparation
 - [skill-creator](https://github.com/anthropics/skills/tree/main/skills/skill-creator) - Template / helper to build new Claude skills.  
 - [template-skill](https://github.com/anthropics/skills/tree/main/template) - Minimal skeleton for a new skill project structure.
@@ -164,6 +163,7 @@
 - [glitternetwork/pinme](https://github.com/glitternetwork/skills/tree/main/pinme) - PinMe is a zero-config frontend deployment tool. No servers. No accounts. No setup.
 - [linkedin](https://github.com/Linked-API/linkedin-skills) - General-purpose LinkedIn automation via Linked API — fetch profiles, search people/companies, send messages, manage connections, create posts. Supports Sales Navigator.
 - [review-claudemd](https://github.com/ykdojo/claude-code-tips/tree/main/skills/review-claudemd) - Review recent conversations to find improvements for CLAUDE.md files.
+- [skills-janitor](https://github.com/khendzel/skills-janitor) - Audit, track usage, and manage your Claude Code skills. 7 slash commands, zero dependencies.
 
 ## 📰 Articles & Blog Posts
 


### PR DESCRIPTION
## [skills-janitor](https://github.com/khendzel/skills-janitor)

Audit, track usage, and manage your Claude Code skills. 7 slash commands, zero dependencies.

Cross-platform: supports both Claude Code and OpenAI Codex.

**Install:**
```
/plugin marketplace add khendzel/skills-janitor
/plugin install skills-janitor
```

![demo](https://raw.githubusercontent.com/khendzel/skills-janitor/main/demo.gif)