### PR TITLE
Add ironclaw-agent-guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@
 - [varlock-claude-skill](https://github.com/wrsmith108/varlock-claude-skill) - Secure environment variable management ensuring secrets never appear in Claude sessions, terminals, logs, or git commits.
 - [sanitize](https://github.com/openclaw/skills/tree/main/skills/agentward-ai/sanitize) - Detect and redact PII from text files — 15 categories (SSNs, credit cards, API keys, etc.), zero dependencies, all processing local.
 - [webapp-testing](https://github.com/anthropics/skills/tree/main/skills/webapp-testing) - Toolkit for interacting with and testing local web applications using Playwright.
+- [ironclaw-agent-guard](https://github.com/wd041216-bit/ironclaw-agent-guard) - Security review skill and CLI/MCP companion for risky tool calls, prompt injection, secret redaction, and audit-friendly agent workflows.
 
 
 


### PR DESCRIPTION
## Summary
- add ironclaw-agent-guard to Security & Web Testing
- position it as a Claude-compatible security review skill with CLI and MCP companions
- link the repo as a reusable guardrail package for prompt injection, secret redaction, and risky tool-call review

## Validation
- GitHub release: https://github.com/wd041216-bit/ironclaw-agent-guard/releases/tag/v0.3.0
- npm package: https://www.npmjs.com/package/@wd041216-bit/ironclaw-agent-guard
