### PR TITLE
Add cc-safe-setup to Security & Web Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,10 +150,11 @@
 - [varlock-claude-skill](https://github.com/wrsmith108/varlock-claude-skill) - Secure environment variable management ensuring secrets never appear in Claude sessions, terminals, logs, or git commits.
 - [sanitize](https://github.com/openclaw/skills/tree/main/skills/agentward-ai/sanitize) - Detect and redact PII from text files — 15 categories (SSNs, credit cards, API keys, etc.), zero dependencies, all processing local.
 - [webapp-testing](https://github.com/anthropics/skills/tree/main/skills/webapp-testing) - Toolkit for interacting with and testing local web applications using Playwright.
+- [cc-safe-setup](https://github.com/yurukusa/cc-safe-setup) - One-command safety hooks for Claude Code: blocks destructive commands, prevents secret leaks, guards branch pushes. 330+ hooks via `npx cc-safe-setup --shield`.
 
 
 
-## 🔧 Utility & Automation  
+## 🔧 Utility & Automation
 - [file-organizer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/file-organizer) - Intelligently organizes your files and folders across your computer.
 - [invoice-organizer](https://github.com/ComposioHQ/awesome-claude-skills/blob/master/invoice-organizer/SKILL.md) - Automatically organizes invoices and receipts for tax preparation
 - [skill-creator](https://github.com/anthropics/skills/tree/main/skills/skill-creator) - Template / helper to build new Claude skills.  


### PR DESCRIPTION
Adds [cc-safe-setup](https://github.com/yurukusa/cc-safe-setup) to the Security & Web Testing section.
**What it does:** One command (`npx cc-safe-setup --shield`) installs safety hooks that block destructive commands, prevent secret leaks, and guard branch pushes. Built after real incidents like [C:\Users lost to rm -rf](https://github.com/anthropics/claude-code/issues/36339).
330+ hooks, 46 CLI commands, 960 tests, 5 languages. MIT licensed. 8,000+ npm downloads/week.