### PR TITLE
Add skill-security-auditor, memory-maintenance, claudemd-maintenance, skills-collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@
 - [OpenPaw](https://github.com/daxaur/openpaw) - 38-skill bundle that turns Claude Code into a personal assistant. Includes git, Telegram, Discord, Obsidian, daily briefing, and more. Run via `npx pawmode`.
 - [agentskill.sh](https://agentskill.sh) - Browse and install 69,000+ AI agent skills for Claude Code, Cursor, Copilot, Windsurf, Zed, and 20+ AI tools.
 - [Agent Almanac](https://github.com/pjt222/agent-almanac) - 317 skills, 65 agents, and 14 teams for Claude Code following the Agent Skills open standard across 50+ domains.
-- [claude-curated](https://github.com/nardovibecoding/claude-curated) - 9 original Claude Code skills — security scanning, adversarial review, memory lifecycle, adaptive summarization, CLAUDE.md optimization, and more.
+- [claude-curated](https://github.com/nardovibecoding/claude-curated) - 8 production-tested Claude Code skills — adversarial review, security scanning, memory lifecycle, adaptive summarization, CLAUDE.md optimization.
 
 ## 🤝 Contribution
 


### PR DESCRIPTION
## Added Skills

### 🛡 Security & Web Testing
- **[skill-security-auditor](https://github.com/nardovibecoding/claude-skill-security-auditor)** — Scan Claude Code skills for malicious code, prompt injection, and exfiltration before installation. 60 detection patterns across 14 threat categories.

### 🔧 Utility & Automation
- **[memory-maintenance](https://github.com/nardovibecoding/claude-skill-memory-maintenance)** — Automated memory lifecycle: mine sessions, detect stale entries, promote patterns to rules, capacity monitoring.
- **[claudemd-maintenance](https://github.com/nardovibecoding/claude-skill-claudemd-maintenance)** — Audit CLAUDE.md rules: classify as internalized/custom/historical/redundant, trim bloat, save context window tokens.

### 🗂️ Collections
- **[claude-code-skills-collection](https://github.com/nardovibecoding/claude-code-skills-collection)** — 8 battle-tested skills including adversarial code review, refactoring safety, adaptive summarization.

All repos are MIT licensed, work on macOS/Linux/Windows, and include demo GIFs.