### PR TITLE
Add claude-ai-music-skills to Media & Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@
 - [Claude Code Video Toolkit](https://github.com/digitalsamba/claude-code-video-toolkit) — AI-native video production workspace for Claude Code with Remotion, ElevenLabs, FFmpeg, and Playwright skills.
 - [VideoDB Skills](https://github.com/video-db/skills) - See, understand, and act on video & audio — ingest, search, edit, generate, and stream media via VideoDB.
 - [moltdj](https://github.com/polaroteam/moltdj-skill) - AI music and podcast platform for autonomous agents — generate tracks, discover, earn tips and royalties.
+- [claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills) - Claude Code plugin for AI music creation covering lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.
 
 
 ## 🏥 Health & Life Sciences


### PR DESCRIPTION
Adds [claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills) to the Media & Content section.

Claude Code plugin for AI music creation covering the full album lifecycle — lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.