### PR TITLE
Add AlterLab GameForge, Academic Skills, and FC Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@
 - [OpenPaw](https://github.com/daxaur/openpaw) - 38-skill bundle that turns Claude Code into a personal assistant. Includes git, Telegram, Discord, Obsidian, daily briefing, and more. Run via `npx pawmode`.
 - [agentskill.sh](https://agentskill.sh) - Browse and install 69,000+ AI agent skills for Claude Code, Cursor, Copilot, Windsurf, Zed, and 20+ AI tools.
 - [Agent Almanac](https://github.com/pjt222/agent-almanac) - 317 skills, 65 agents, and 14 teams for Claude Code following the Agent Skills open standard across 50+ domains.
+- [AlterLab-FC-Skills](https://github.com/AlterLab-IEU/AlterLab-FC-Skills) - 72 agentic skills for creative technology workflows across 11 domains.
+- [AlterLab-Academic-Skills](https://github.com/AlterLab-IEU/AlterLab-Academic-Skills) - 2,097 academic skill MDs for higher education and research contexts.
+- [AlterLab_GameForge](https://github.com/AlterLab-IEU/AlterLab_GameForge) - 34 game development skills covering design, mechanics, and production pipelines.
 
 ## 🤝 Contribution
 


### PR DESCRIPTION
## Summary

Adding three open-source Claude Code skill collections from AlterLab:

- **[AlterLab GameForge](https://github.com/AlterLab-IEU/AlterLab_GameForge)** — 34 game development skills: studio management agents, dev workflow tools, and engine specialists for Godot, Unity, and Unreal. Added to **Development & Code Tools**.

- **[AlterLab Academic Skills](https://github.com/AlterLab-IEU/AlterLab-Academic-Skills)** — 186+ academic research skills covering bioinformatics, cheminformatics, data science, databases, clinical research, and scientific writing. Added to **Scientific & Research Tools**.

- **[AlterLab FC Skills](https://github.com/AlterLab-IEU/AlterLab-FC-Skills)** — 72 skills for communication students covering PR & advertising, cinema, new media, visual design, research methods, and generative AI production. Added to **Learning & Knowledge**.

All three repos are public, MIT-licensed, and follow the standard Claude Code skill format with SKILL.md files.