### PR TITLE
Add AKF — The AI Native File Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 
 
 ## 🛠 Development & Code Tools
+- [AKF — The AI Native File Format](https://github.com/HMAKT99/AKF) - EXIF for AI. Stamps every file with trust scores, source provenance, and compliance metadata (~15 tokens of JSON). Embeds into 20+ formats (DOCX, PDF, images, code). MCP server, shell hook, EU AI Act auditing. [akf.dev](https://akf.dev)
 - [web-artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.


### PR DESCRIPTION
AKF is the AI native file format — EXIF for AI. Stamps every file with trust scores, source provenance, and compliance metadata.

- ~15 tokens of JSON, embeds into 20+ formats
- MCP server with 9 tools
- Shell hook auto-stamps AI outputs
- EU AI Act, SOX, HIPAA compliance
- `pip install akf` | https://akf.dev