### PR TITLE
Add Public Google Drive skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@
 - [plannotator](https://github.com/backnotprop/plannotator) - Interactive plan review UI for Claude Code with visual annotation, offline sharing, and Obsidian/Bear integration.
 - [claude-skills](https://github.com/jeffallan/claude-skills) - 9 project workflow commands (discovery, planning, execution, retrospectives) with Jira/Confluence integration.
 - [outline](https://github.com/sanjay3290/ai-skills/tree/main/skills/outline) - Search, read, create, and manage documents in Outline wiki instances (cloud or self-hosted).
+- [public-google-drive](https://github.com/zagmoai/public-google-drive) - Create and edit Google Docs and Sheets without Google sign-in. Documents are hosted on Memyard and viewable at shareable links.
 - [google-workspace-skills](https://github.com/sanjay3290/ai-skills/tree/main/skills) - Suite of Google Workspace integrations: Gmail, Google Calendar, Google Chat, Google Docs, Google Sheets, Google Slides, and Google Drive. Lightweight alternatives to full MCP servers with cross-platform OAuth.
 - [pm-skills](https://github.com/product-on-purpose/pm-skills) - 24 product management skills across the Triple Diamond lifecycle with agentskills.io spec compliance, templates, and MCP server support.
 - [Product-Manager-Skills](https://github.com/deanpeters/Product-Manager-Skills) - Product management skill library covering discovery, prioritization, PRDs, roadmap planning, and SaaS metrics.


### PR DESCRIPTION
Adds [Public Google Drive](https://github.com/zagmoai/public-google-drive) — an agent skill that lets coding agents create and edit Google Docs and Sheets without Google sign-in.

- Documents hosted on Memyard, viewable at shareable links
- Works with Claude Code, Cursor, Codex, and OpenClaw
- Auto-registration on first use (no setup, no API keys to copy)
- MIT licensed with full SKILL.md documentation