### PR TITLE
Add Spartan AI Toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@
 - [Playwright Skill](https://github.com/testdino-hq/playwright-skill) - AI agent-ready Playwright skill with structured SKILL.md, test automation workflows, and MCP-compatible setup for real-world testing pipelines.
 - [Emblem AI Agent Wallet](https://github.com/EmblemCompany/Agent-skills/tree/main/skills/emblem-ai-agent-wallet) - Multi-chain crypto wallet management across 7 blockchains (Solana, Ethereum, Base, BSC, Polygon, Hedera, Bitcoin), swaps and transfers.
 - [unity-agent-skills](https://github.com/jahro-console/unity-agent-skills) - Agent skills set for AI-assisted Unity debugging — structured logging, runtime commands, variable watching, and more.
+- [spartan-ai-toolkit](https://github.com/spartan-stratos/spartan-ai-toolkit) - Engineering workflow commands with quality gates, TDD enforcement, and atomic commits for AI coding agents.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
Adding Spartan AI Toolkit to the Development & Code Tools section.

- 56 slash commands, 12 coding rules, 22 skills
- Quality gates: spec → plan → TDD → review → PR
- Configurable rules for 8 stacks
- Works with Claude Code, Codex, Cursor, Windsurf, Copilot

https://github.com/spartan-stratos/spartan-ai-toolkit