### PR TITLE
Add Claude Code Cheat Sheet to Learning & Knowledge

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@
 
 
 ## 📘 Learning & Knowledge  
+- [claude-code-cheat-sheet](https://cc.storyfox.cz/) - Complete one-page printable reference with all Claude Code shortcuts, commands, CLI flags, MCP config, memory, skills, and agents. Auto-updated daily from official docs. Available in EN, ZH, JA, KO.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.  
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 


### PR DESCRIPTION
Adding [Claude Code Cheat Sheet](https://cc.storyfox.cz/) to the Learning & Knowledge section.

- One-page printable reference with all shortcuts, commands, CLI flags, MCP config, memory, skills, and agents
- Auto-updated daily from official docs
- Available in 4 languages: [EN](https://cc.storyfox.cz/), [ZH](https://cc.storyfox.cz/zh/), [JA](https://cc.storyfox.cz/jp/), [KO](https://cc.storyfox.cz/kr/)
- Hit HN frontpage with 130k+ pageviews