### PR TITLE
Add persona-compass - AI-powered interpersonal communication skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@
 - [template-skill](https://github.com/anthropics/skills/tree/main/template) - Minimal skeleton for a new skill project structure.
 - [agentfund-mcp](https://github.com/RioTheGreat-ai/agentfund-mcp) - Crowdfunding for AI agents. Milestone-based escrow on Base chain for proposals, project tracking, and payments.
 - [task-observer](https://github.com/rebelytics/one-skill-to-rule-them-all) - A meta-skill that builds and improves all your skills, including itself.
+- * [persona-compass](https://github.com/snowyowlmia/persona-compass) - Build AI-powered personality models of colleagues and get actionable communication strategies. Predict behavior, generate ready-to-use message drafts, navigate office politics with a privacy-first codename system. Zero dependencies, works on Claude Code and Claude.ai.
 - [glitternetwork/pinme](https://github.com/glitternetwork/skills/tree/main/pinme) - PinMe is a zero-config frontend deployment tool. No servers. No accounts. No setup.
 - [linkedin](https://github.com/Linked-API/linkedin-skills) - General-purpose LinkedIn automation via Linked API — fetch profiles, search people/companies, send messages, manage connections, create posts. Supports Sales Navigator.
 - [moodtrip-hotel-search](https://github.com/adiny/moodtrip-hotel-search) - Hotel search, comparison, reviews, pricing, and booking handoff via MoodTrip.ai MCP server. 12 tools including semantic search, room matching, and price intelligence.


### PR DESCRIPTION
Adds persona-compass: a skill for building AI personality models of colleagues and getting actionable communication strategies. Zero dependencies, works on Claude Code and Claude.ai.
