### PR TITLE
Add review-loop to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@
 - [Playwright Skill](https://github.com/testdino-hq/playwright-skill) - AI agent-ready Playwright skill with structured SKILL.md, test automation workflows, and MCP-compatible setup for real-world testing pipelines.
 - [Emblem AI Agent Wallet](https://github.com/EmblemCompany/Agent-skills/tree/main/skills/emblem-ai-agent-wallet) - Multi-chain crypto wallet management across 7 blockchains (Solana, Ethereum, Base, BSC, Polygon, Hedera, Bitcoin), swaps and transfers.
 - [unity-agent-skills](https://github.com/jahro-console/unity-agent-skills) - Agent skills set for AI-assisted Unity debugging — structured logging, runtime commands, variable watching, and more.
+- [review-loop](https://github.com/NYTC69/review-loop) - Automates Plan-Execute-Review loops with cross-AI code review using an independent Reviewer (e.g. OpenAI Codex CLI) to catch blind spots a single agent would miss.
 - [spartan-ai-toolkit](https://github.com/spartan-stratos/spartan-ai-toolkit) - Engineering workflow commands with quality gates, TDD enforcement, and atomic commits for AI coding agents.
 
 


### PR DESCRIPTION
## Summary

- Adds [review-loop](https://github.com/NYTC69/review-loop) to the **Development & Code Tools** section
- review-loop is a Claude Code plugin that automates Plan-Execute-Review loops with cross-AI code review, using an independent Reviewer (e.g. OpenAI Codex CLI) to catch blind spots a single agent would miss
- Apache 2.0 licensed, installable via `/plugin marketplace add NYTC69/review-loop`

## Details

- Entry follows the existing list format (name, link, one-line description)
- Placed in the Development & Code Tools section alongside other engineering workflow and code quality tools