### PR TITLE
Add TokRepo to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@
 - [find-skills](https://github.com/agentbay-ai/agentbay-skills) - Helps users discover, search and install agent skills from the marketplace.
 - [OpenPaw](https://github.com/daxaur/openpaw) - 38-skill bundle that turns Claude Code into a personal assistant. Includes git, Telegram, Discord, Obsidian, daily briefing, and more. Run via `npx pawmode`.
 - [agentskill.sh](https://agentskill.sh) - Browse and install 69,000+ AI agent skills for Claude Code, Cursor, Copilot, Windsurf, Zed, and 20+ AI tools.
+- [TokRepo](https://github.com/henu-wang/tokrepo) - Open registry for AI assets with CLI and MCP access to discover installable skills, prompts, MCP configs, and workflows.
 - [Agent Almanac](https://github.com/pjt222/agent-almanac) - 317 skills, 65 agents, and 14 teams for Claude Code following the Agent Skills open standard across 50+ domains.
 - [AlterLab-FC-Skills](https://github.com/AlterLab-IEU/AlterLab-FC-Skills) - 72 agentic skills for creative technology workflows across 11 domains.
 - [AlterLab-Academic-Skills](https://github.com/AlterLab-IEU/AlterLab-Academic-Skills) - 186+ academic research skills across 13 domains for higher education and research.


### PR DESCRIPTION
This adds TokRepo to the Collections section as an open registry for installable AI assets.

Why it fits:
- TokRepo is a GitHub-discoverable registry for skills, prompts, MCP configs, and workflows
- it is positioned here as a collection/discovery resource, not an individual skill
- the description is kept short and neutral to match the rest of the list

Happy to adjust the wording if you prefer a different placement.