### PR TITLE
Add deep-dive-skill to Scientific & Research Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews.
 - [manus](https://github.com/sanjay3290/ai-skills/tree/main/skills/manus) - Delegate complex tasks to Manus AI agent for deep research, market analysis, product comparisons, stock analysis, and comprehensive report generation with parallel processing.
 - [paper-search](https://github.com/ykdojo/paper-search) - Search academic papers via OpenAlex (250M+ works, free, no API key needed). Find papers by keyword, look up details by DOI, with sorting and pagination.
+- [deep-dive-skill](https://github.com/kimsb2429/deep-dive-skill) - DAG-based deep research that breaks questions into dependency-ordered sub-questions, runs them as parallel subagents, identifies gaps, and writes a sourced report. No external APIs needed.
 
 
 ## ✍️ Writing & Research


### PR DESCRIPTION
Adds [deep-dive-skill](https://github.com/kimsb2429/deep-dive-skill) to the Scientific & Research Tools section.

**What it does:** Breaks any research question into a dependency graph (DAG) of sub-questions, runs them as parallel subagents, identifies gaps, iterates, and writes a sourced report to the project's docs directory.

**Why it's different:** Among 7+ community research skills surveyed, this is the only one that uses DAG-based planning with dependency ordering (others use linear pipelines). Single markdown file, no external APIs or MCP servers required.

**Category:** Scientific & Research Tools