### PR TITLE
Add imessage-with-no-mac skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@
 - [agentfund-mcp](https://github.com/RioTheGreat-ai/agentfund-mcp) - Crowdfunding for AI agents. Milestone-based escrow on Base chain for proposals, project tracking, and payments.
 - [task-observer](https://github.com/rebelytics/one-skill-to-rule-them-all) - A meta-skill that builds and improves all your skills, including itself.
 - [glitternetwork/pinme](https://github.com/glitternetwork/skills/tree/main/pinme) - PinMe is a zero-config frontend deployment tool. No servers. No accounts. No setup.
+- [imessage-with-no-mac](https://github.com/emotion-machine-org/imessage-with-no-mac) - iMessage, RCS & SMS for AI agents without a Mac. Dedicated phone number, WebSocket API, tapbacks, typing indicators, group chats. Powered by Claw Messenger.
 - [linkedin](https://github.com/Linked-API/linkedin-skills) - General-purpose LinkedIn automation via Linked API — fetch profiles, search people/companies, send messages, manage connections, create posts. Supports Sales Navigator.
 - [moodtrip-hotel-search](https://github.com/adiny/moodtrip-hotel-search) - Hotel search, comparison, reviews, pricing, and booking handoff via MoodTrip.ai MCP server. 12 tools including semantic search, room matching, and price intelligence.
 - [review-claudemd](https://github.com/ykdojo/claude-code-tips/tree/main/skills/review-claudemd) - Review recent conversations to find improvements for CLAUDE.md files.


### PR DESCRIPTION
Adds [imessage-with-no-mac](https://github.com/emotion-machine-org/imessage-with-no-mac) to Utility & Automation. iMessage, RCS & SMS for AI agents without a Mac.