### PR TITLE
Add karpathy-llm-wiki to Learning & Knowledge

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@
 
 
 ## 📘 Learning & Knowledge  
+- [karpathy-llm-wiki](https://github.com/Astro-Han/karpathy-llm-wiki) - Markdown-first skill for building and maintaining a personal LLM wiki from raw sources, compiled knowledge pages, query workflows, and linting.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.  
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 


### PR DESCRIPTION
Add `karpathy-llm-wiki` to the Learning & Knowledge section.

It is a markdown-first skill for building and maintaining a personal LLM wiki with source ingestion into `raw/`, compiled knowledge pages in `wiki/`, query workflows, and linting guidance.

Repo: https://github.com/Astro-Han/karpathy-llm-wiki
License: MIT