### PR TITLE
Add session-continuity to Utility & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@
 - [review-claudemd](https://github.com/ykdojo/claude-code-tips/tree/main/skills/review-claudemd) - Review recent conversations to find improvements for CLAUDE.md files.
 - [hubspot-admin-skills](https://github.com/TomGranot/hubspot-admin-skills) - Skills for auditing, cleaning, enriching, and automating HubSpot CRM. Full audit → plan → execute → maintain workflow.
 - [SkillCheck-Free](https://github.com/olgasafonova/SkillCheck-Free) - Free SKILL.md validator with 30+ checks across structure, naming, and semantics. Catches common errors before deploying Claude Code skills.
+- [session-continuity](https://github.com/manja316/claude-session-continuity) - Anti-amnesia skill that auto-checkpoints working state to survive context compaction and session restarts. Saves decisions, progress, and next steps to a state file so Claude resumes with full context.
 
 ## 📰 Articles & Blog Posts
 


### PR DESCRIPTION
Adds [session-continuity](https://github.com/manja316/claude-session-continuity) — an anti-amnesia skill that checkpoints working state so Claude resumes with full context after session restarts or context compaction.

Placed in the Utility & Automation section at the end of the list.