### PR TITLE
Add dependency-auditor to Security & Web Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@
 - [sanitize](https://github.com/openclaw/skills/tree/main/skills/agentward-ai/sanitize) - Detect and redact PII from text files — 15 categories (SSNs, credit cards, API keys, etc.), zero dependencies, all processing local.
 - [webapp-testing](https://github.com/anthropics/skills/tree/main/skills/webapp-testing) - Toolkit for interacting with and testing local web applications using Playwright.
 - [ironclaw-agent-guard](https://github.com/wd041216-bit/ironclaw-agent-guard) - Security review skill and CLI/MCP companion for risky tool calls, prompt injection, secret redaction, and audit-friendly agent workflows.
+- [dependency-auditor](https://github.com/manja316/claude-dependency-auditor) - Multi-ecosystem dependency security auditor with noise filtering. Runs real audit tools across 7 ecosystems and classifies findings into four priority tiers: critical-runtime, dev-only, transitive-unreachable, and disputed/withdrawn.
 
 
 


### PR DESCRIPTION
Adds [dependency-auditor](https://github.com/manja316/claude-dependency-auditor) — a multi-ecosystem dependency security auditor that runs real audit tools (npm audit, pip-audit, cargo audit, etc.) and classifies findings into actionable priority tiers.

Placed in the Security & Web Testing section at the end of the list.