### PR TITLE
Add PuzzleGenio skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@
 - [glitternetwork/pinme](https://github.com/glitternetwork/skills/tree/main/pinme) - PinMe is a zero-config frontend deployment tool. No servers. No accounts. No setup.
 - [linkedin](https://github.com/Linked-API/linkedin-skills) - General-purpose LinkedIn automation via Linked API — fetch profiles, search people/companies, send messages, manage connections, create posts. Supports Sales Navigator.
 - [moodtrip-hotel-search](https://github.com/adiny/moodtrip-hotel-search) - Hotel search, comparison, reviews, pricing, and booking handoff via MoodTrip.ai MCP server. 12 tools including semantic search, room matching, and price intelligence.
+- [puzzlegenio](https://github.com/fruitwyatt/puzzlegenio-claude-skill) - Generate free printable puzzles (crossword, word search, sudoku, jigsaw, bingo, nonogram) with pre-filled deep links for classrooms, parties, and gifts.
 - [review-claudemd](https://github.com/ykdojo/claude-code-tips/tree/main/skills/review-claudemd) - Review recent conversations to find improvements for CLAUDE.md files.
 - [hubspot-admin-skills](https://github.com/TomGranot/hubspot-admin-skills) - Skills for auditing, cleaning, enriching, and automating HubSpot CRM. Full audit → plan → execute → maintain workflow.
 - [SkillCheck-Free](https://github.com/olgasafonova/SkillCheck-Free) - Free SKILL.md validator with 30+ checks across structure, naming, and semantics. Catches common errors before deploying Claude Code skills.


### PR DESCRIPTION
## Summary

Adds [PuzzleGenio](https://github.com/fruitwyatt/puzzlegenio-claude-skill) to the Utility & Automation category.

**What it does:** A Claude Code skill that generates free printable puzzles — crossword, word search, sudoku, jigsaw, bingo, and nonogram — with pre-filled deep links ready to share.

**Who it helps:** Teachers creating classroom worksheets, parents planning party activities, and anyone who wants a custom puzzle in seconds without manual setup.

**Example:** Ask Claude "make a 15x15 word search about ocean animals" and get a ready-to-print puzzle page with answer key at `https://puzzlegenio.com/tools/printable-word-search-maker?words=dolphin,whale,octopus,...`