### PR TITLE
Add codebase-recon skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
 - [plugin-authoring](https://github.com/ivan-magda/claude-code-plugin-template/tree/main/plugins/plugin-development/skills/plugin-authoring) - Ambient guidance for creating, modifying, and debugging Claude Code plugins with schemas, templates, validation workflows, and troubleshooting.
 - [azure-devops](https://github.com/sanjay3290/ai-skills/tree/main/skills/azure-devops) - Manage Azure DevOps projects, repos, PRs, pipelines, and work items via REST API.
 - [claude-skills](https://github.com/jeffallan/claude-skills) - 65 full-stack development skills with progressive disclosure, covering React, NestJS, Python, DevOps, and 30+ frameworks.
+- [codebase-recon](https://github.com/yujiachen-y/codebase-recon-skill) - Analyze git history to reveal codebase hotspots, bug magnets, bus factor risks, team momentum, and development patterns before reading any code.
 - [jules](https://github.com/sanjay3290/ai-skills/tree/main/skills/jules) - Delegate coding tasks to Google Jules AI agent for async bug fixes, documentation, tests, and feature implementation on GitHub repos.
 - [hashicorp-agent-skills](https://github.com/hashicorp/agent-skills) - HashiCorp-maintained Claude skills for Terraform workflows and infrastructure automation.
 - [agnix](https://github.com/avifenesh/agnix) - Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP configs, and more with 156 rules, auto-fix, and LSP server for real-time editor diagnostics.


### PR DESCRIPTION
Adds [codebase-recon](https://github.com/yujiachen-y/codebase-recon-skill) to the Development & Code Tools section.

A coding agent skill that analyzes git history to understand a codebase before reading any code. It reveals:
- **Code hotspots** — most-changed files
- **Bug magnets** — files associated with fix commits
- **High-risk files** — cross-referenced hotspots × bug magnets
- **Bus factor** — knowledge concentration risk
- **Team momentum** — development trend (rising/stable/declining)
- **Firefighting frequency** — reverts, hotfixes, emergency commits

Works with 20+ coding agents via [Agent Skills Specification](https://agentskills.io/specification): Claude Code, Cursor, Cline, GitHub Copilot, Gemini CLI, and more.

Inspired by ["The Git Commands I Run Before Reading Any Code"](https://piechowski.io/post/git-commands-before-reading-code/) by Ally Piechowski.