### PR TITLE
Add toprank to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@
 - [@clawfu/mcp-skills](https://github.com/guia-matthieu/clawfu-skills) - 169 expert-sourced marketing skills (Dunford, Schwartz, Ogilvy, Cialdini) as MCP server with brand memory.
 - [wondelai/skills](https://github.com/wondelai/skills) - 25 agent skills for UX design, marketing/CRO, sales, product strategy, and growth based on books by Norman, Cialdini, Ries, Hormozi, and others.
 - [devmarketing-skills](https://github.com/jonathimer/devmarketing-skills) - 33 skills for developer marketing — HN strategy, technical tutorials, docs-as-marketing, Reddit engagement, developer onboarding, newsletters, and SEO for devtools.
+- [toprank](https://github.com/nowork-studio/toprank) - 9 SEO and Google Ads skills for Claude Code. Connects Google Search Console, PageSpeed Insights, and Google Ads API to audit traffic and wasted ad spend, rewrite meta tags, generate JSON-LD schema markup, and ship fixes to WordPress/Strapi/Contentful/Ghost. MIT licensed, 107 stars.
 - [find-skills](https://github.com/agentbay-ai/agentbay-skills) - Helps users discover, search and install agent skills from the marketplace.
 - [OpenPaw](https://github.com/daxaur/openpaw) - 38-skill bundle that turns Claude Code into a personal assistant. Includes git, Telegram, Discord, Obsidian, daily briefing, and more. Run via `npx pawmode`.
 - [agentskill.sh](https://agentskill.sh) - Browse and install 69,000+ AI agent skills for Claude Code, Cursor, Copilot, Windsurf, Zed, and 20+ AI tools.


### PR DESCRIPTION
Adds **toprank** to the Collections section, alongside existing marketing skill bundles like `@clawfu/mcp-skills`, `wondelai/skills`, and `devmarketing-skills`.

toprank is a 9-skill Claude Code plugin focused on SEO and Google Ads. It connects Claude Code to Google Search Console, PageSpeed Insights, and the Google Ads API, then actually ships fixes — meta tag rewrites, JSON-LD schema markup, keyword bid adjustments, and content pushes to WordPress/Strapi/Contentful/Ghost.

## Traction
- **107 GitHub stars, 14 forks**
- MIT licensed, actively maintained
- CHANGELOG, unit tests, and LLM-judge eval tests
- Full per-skill reference documentation

- Source: https://github.com/nowork-studio/toprank
- Install: `/plugin marketplace add nowork-studio/toprank`