### PR TITLE
Add voice-to-instrument-guide to Media & Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@
 - [VideoDB Skills](https://github.com/video-db/skills) - See, understand, and act on video & audio — ingest, search, edit, generate, and stream media via VideoDB.
 - [moltdj](https://github.com/polaroteam/moltdj-skill) - AI music and podcast platform for autonomous agents — generate tracks, discover, earn tips and royalties.
 - [claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills) - Claude Code plugin for AI music creation covering lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.
+- [voice-to-instrument-guide](https://github.com/stark-ydq/voice-to-instrument-skills) - Expert guidance for converting voice recordings into realistic instrument sounds — covers recording best practices, instrument-specific tips (piano, guitar, violin, drums, saxophone, flute, cello, trumpet, bass, clarinet), and prompt engineering for music AI tools.
 
 
 ## 🏥 Health & Life Sciences


### PR DESCRIPTION
## Summary

Adds [voice-to-instrument-guide](https://github.com/stark-ydq/voice-to-instrument-skills) to the **🎬 Media & Content** section, right after the existing music-related entries.

## What the skill does

A focused, MIT-licensed Agent Skill that helps AI assistants give high-quality advice on voice-to-instrument AI music production:

- **Recording best practices** — microphone setup, environment, vocal technique, file formats
- **Instrument-specific tips** — tailored guidance for piano, guitar, violin, drums, saxophone, flute, cello, trumpet, bass, and clarinet
- **Prompt engineering** — how to write effective prompts for text-to-music and voice-conversion AI tools
- **Troubleshooting** — diagnosing muddy, robotic, off-rhythm, or clipped outputs

## Why it fits

- Pure markdown (no code execution, no telemetry, no network calls)
- 100% open source under MIT license
- Complements the existing ``claude-ai-music-skills`` and ``moltdj`` entries in Media & Content
- Follows the existing bullet format exactly

Repository: https://github.com/stark-ydq/voice-to-instrument-skills