### PR TITLE
Add tldr skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@
 - [review-claudemd](https://github.com/ykdojo/claude-code-tips/tree/main/skills/review-claudemd) - Review recent conversations to find improvements for CLAUDE.md files.
 - [hubspot-admin-skills](https://github.com/TomGranot/hubspot-admin-skills) - Skills for auditing, cleaning, enriching, and automating HubSpot CRM. Full audit → plan → execute → maintain workflow.
 - [SkillCheck-Free](https://github.com/olgasafonova/SkillCheck-Free) - Free SKILL.md validator with 30+ checks across structure, naming, and semantics. Catches common errors before deploying Claude Code skills.
+- [tldr](https://github.com/shihyuho/skills/tree/main/skills/tldr) - Produce a concise TL;DR of any target — files, PRs, diffs, or URLs.
 
 ## 📰 Articles & Blog Posts
 


### PR DESCRIPTION
A minimalist 4-sentence skill that produces TL;DR digests of any target — files, directories, PRs, diffs, or URLs — in roughly 2 minutes. When something stands out, it suggests follow-up tldr targets. Works with any agent that supports skills.