### PR TITLE
Add Product Org OS to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@
 - [AlterLab-Academic-Skills](https://github.com/AlterLab-IEU/AlterLab-Academic-Skills) - 186+ academic research skills across 13 domains for higher education and research.
 - [AlterLab_GameForge](https://github.com/AlterLab-IEU/AlterLab_GameForge) - 34 game development skills covering design, mechanics, and production pipelines.
 - [Claude Code SDK](https://github.com/SeifBenayed/claude-code-sdk) - Open-source, provider-agnostic CLI for AI agents. 13 providers, built-in tools, skill marketplace.
+- [Product Org OS](https://github.com/yohayetsion/product-org-os) - Claude Code plugin that models a full product organization: 150+ skills for PRDs, roadmaps, business cases, GTM, pricing, and strategy frameworks, 12 role-based agents (CPO, VP Product, PM, PMM, BizOps, Competitive Intelligence, and more), plus two gateways — `/product` auto-routes to the right role and `/plt` convenes a multi-stakeholder leadership meeting. Built on the Vision to Value 6-phase methodology. MIT licensed.
 
 
 ## 🤝 Contribution


### PR DESCRIPTION
Adds Product Org OS to the Collections section — a Claude Code plugin that models a full product organization with 150+ skills spanning PRDs, roadmaps, business cases, GTM, pricing, and 31 strategy frameworks, powered by 12 role-based agents (CPO, VP Product, PM, PMM, BizOps, CI, and more). v4.0 introduces enforcement-first agent declarations, 38 knowledge packs, and 20 cross-domain specialist skills in legal, HR, design, and architecture. Two gateways: `/product` auto-routes to the right agent, `/plt` runs a multi-stakeholder Product Leadership Team meeting. Built on the Vision to Value methodology, MIT licensed, installable via `claude plugins install github:yohayetsion/product-org-os`. Fits alongside Agent Almanac and other multi-skill bundles in Collections.