### PR TITLE
Add superseo-skills to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@
 - [AlterLab-Academic-Skills](https://github.com/AlterLab-IEU/AlterLab-Academic-Skills) - 186+ academic research skills across 13 domains for higher education and research.
 - [AlterLab_GameForge](https://github.com/AlterLab-IEU/AlterLab_GameForge) - 34 game development skills covering design, mechanics, and production pipelines.
 - [Claude Code SDK](https://github.com/SeifBenayed/claude-code-sdk) - Open-source, provider-agnostic CLI for AI agents. 13 providers, built-in tools, skill marketplace.
+- [superseo-skills](https://github.com/inhouseseo/superseo-skills) - 11 SEO skills for page audits, content briefs, article writing, E-E-A-T audits, semantic gap analysis, featured snippets, topic clusters, and link building. Each skill fetches pages and reads top-ranking competitors itself, so no keyword exports are needed.
 
 
 ## 🤝 Contribution


### PR DESCRIPTION
Adds [superseo-skills](https://github.com/inhouseseo/superseo-skills) to the 🗂️ Collections section.

It's an 11-skill bundle focused on SEO workflows (page audits, content briefs, article writing, E-E-A-T audits, semantic gap analysis, featured snippets, topic clusters, link building), so Collections is a better fit than the single-skill sections. Apache 2.0, plugin-marketplace install, working SKILL.md + YAML frontmatter on every skill.

The differentiator vs other SEO skills: each skill fetches the page and reads top-ranking competitors itself, so users don't need to paste in keyword data exports.

(Note: this PR was originally opened against Writing & Research — I've moved the entry to Collections and updated the title.)