### PR TITLE
Add SwarmVault

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@
 ## 📘 Learning & Knowledge  
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.  
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
+- [swarmvault](https://github.com/swarmclawai/swarmvault) - Local-first RAG knowledge base compiler. Turns raw docs, research, and code into a persistent markdown wiki, knowledge graph, and hybrid SQLite FTS + embeddings search. Ships a bundled skill and MCP server; works with Claude Code, Codex, and OpenCode.
 
 
 


### PR DESCRIPTION
Adding SwarmVault to the Learning & Knowledge section.

SwarmVault is a local-first RAG knowledge base compiler that turns raw docs, research, and code into a persistent markdown wiki, knowledge graph, and hybrid SQLite FTS + embeddings search. It ships a bundled skill with schema-first, graph-query-first conventions and an MCP server, which fits naturally alongside `tapestry` in the Learning & Knowledge section. Works with Claude Code, Codex, and OpenCode.

- https://github.com/swarmclawai/swarmvault
- https://swarmvault.ai

License: MIT