### PR TITLE
Add Helium MCP to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@
 - [mssql](https://github.com/sanjay3290/ai-skills/tree/main/skills/mssql) - Safe read-only SQL queries against Microsoft SQL Server databases.
 - [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection.
 - [octav-api-skill](https://github.com/Octav-Labs/octav-api-skill) - Query Octav's crypto portfolio API: wallet balances, transaction history, DeFi protocol positions, and token analytics across 20+ chains.
+- [helium-mcp](https://github.com/connerlambden/helium-mcp) - Real-time news intelligence with bias scoring, financial market data, ML options pricing via MCP.
 - [elicitation](https://github.com/tasteray/skills/tree/main/elicitation) - Psychological profiling through natural conversation using narrative identity and Motivational Interviewing techniques.
 - [recommendations](https://github.com/tasteray/skills/tree/main/recommendations) - Personalized recommendations across movies, restaurants, products, travel, and jobs via the TasteRay API.
 


### PR DESCRIPTION
Adds [helium-mcp](https://github.com/connerlambden/helium-mcp) for real-time news intelligence with bias scoring, financial market data, and ML options pricing via MCP.

Made with [Cursor](https://cursor.com)