### PR TITLE
Add llm-wiki skill under Learning & Knowledge

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@
 ## 📘 Learning & Knowledge  
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.  
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
+- [llm-wiki](https://github.com/praneybehl/llm-wiki-plugin) - Build and maintain an LLM-curated personal knowledge base in any project (Karpathy's LLM Wiki pattern). Skill + 5 `/wiki:*` commands with sharded indexes, BM25 search, and a structural lint script — designed to scale to thousands of pages.
 
 
 


### PR DESCRIPTION
Adds [llm-wiki](https://github.com/praneybehl/llm-wiki-plugin) under **📘 Learning & Knowledge** — same category as tapestry, which has a similar knowledge-graph framing.

Implementation of [Andrej Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) as a Claude Code skill + plugin. Ingested sources (papers, articles, transcripts, PDFs, notes) get compiled once into persistent markdown pages; subsequent queries read the pre-synthesized wiki rather than re-chunking raw sources, so knowledge compounds.

**Surface:** `llm-wiki` skill · 5 slash commands (`/wiki:init`, `/wiki:ingest`, `/wiki:query`, `/wiki:lint`, `/wiki:stats`) · 4 stdlib-only Python scripts (init, BM25 search, lint, stats) · marketplace manifest. Installable via `/plugin marketplace add praneybehl/llm-wiki-plugin` or `npx skills add praneybehl/llm-wiki-plugin`.