### PR TITLE
Add MorningAI to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@
 - [coinpaprika-api](https://github.com/coinpaprika/skills/tree/main/coinpaprika-api) - Crypto market data for 12K+ coins, 350+ exchanges, tickers, OHLCV, historical prices. Free, no API key.
 - [dexpaprika-api](https://github.com/coinpaprika/skills/tree/main/dexpaprika-api) - Free DEX data across 34 chains: 30M+ pools, 27M+ tokens, real-time SSE streaming, OHLCV. No API key, no rate limits.
 - [gh-star-history](https://github.com/ykdojo/gh-star-history) - Visualize and compare GitHub star history as interactive charts, with regional breakdown of stargazers.
+- [MorningAI](https://github.com/octo-patch/MorningAI) - AI news tracking skill that monitors 80+ entities across 6 free sources (Reddit, HN, GitHub, HuggingFace, arXiv, X). Generates scored daily reports with infographics and message digests. No API keys required.
 
 
 ## 🔬 Scientific & Research Tools


### PR DESCRIPTION
## Summary

- Adds [MorningAI](https://github.com/octo-patch/MorningAI) to the **Data & Analysis** section
- AI news tracking skill that monitors 80+ entities across 6 free sources (Reddit, HN, GitHub, HuggingFace, arXiv, X/Twitter)
- Generates scored daily reports with infographics and message digests
- No API keys required, works via `/morning-ai` in Claude Code
- MIT licensed