### PR TITLE
Add OpenAccountants project link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@
 - [AlterLab-Academic-Skills](https://github.com/AlterLab-IEU/AlterLab-Academic-Skills) - 186+ academic research skills across 13 domains for higher education and research.
 - [AlterLab_GameForge](https://github.com/AlterLab-IEU/AlterLab_GameForge) - 34 game development skills covering design, mechanics, and production pipelines.
 - [Claude Code SDK](https://github.com/SeifBenayed/claude-code-sdk) - Open-source, provider-agnostic CLI for AI agents. 13 providers, built-in tools, skill marketplace.
+- [OpenAccountants](https://github.com/openaccountants/openaccountants) - 371 tax classification skills across 134 countries covering VAT/GST, income tax, and social contributions. 
 
 
 ## 🤝 Contribution


### PR DESCRIPTION

Adding OpenAccountants to the Collections section. It's an open-source collection of tax classification skills — 371 skills across 134 countries covering VAT/GST, income tax, and social contributions for self-employed workflows. We're a community of CPAs.  MIT licensed.
Fits alongside the other multi-skill repos in Collections.