### PR TITLE
Add buyer-eval to Writing & Research section

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@
 - [avoid-ai-writing](https://github.com/conorbronsdon/avoid-ai-writing) - Audits and rewrites content to remove 21 categories of AI writing patterns with a 43-entry replacement table and two-pass detection.
 - [naming](https://github.com/glacierphonk/naming) - Metaphor-driven naming for products, SaaS, brands, bots, and open source projects. Structured process that produces memorable, meaningful names.
 
-
+- [buyer-eval](https://github.com/salespeak-ai/buyer-eval-skill) - Structured B2B vendor evaluation that interrogates vendor AI agents, cross-references claims against independent sources, and scores across 7 weighted dimensions. MIT licensed.
+- 
 ## 📘 Learning & Knowledge  
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.  
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@
 - [avoid-ai-writing](https://github.com/conorbronsdon/avoid-ai-writing) - Audits and rewrites content to remove 21 categories of AI writing patterns with a 43-entry replacement table and two-pass detection.
 - [naming](https://github.com/glacierphonk/naming) - Metaphor-driven naming for products, SaaS, brands, bots, and open source projects. Structured process that produces memorable, meaningful names.
 
-- [buyer-eval](https://github.com/salespeak-ai/buyer-eval-skill) - Structured B2B vendor evaluation that interrogates vendor AI agents, cross-references claims against independent sources, and scores across 7 weighted dimensions. MIT licensed.
-- 
+- [buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) - Structured B2B vendor evaluation that interrogates vendor AI agents, cross-references claims against independent sources, and scores across 7 weighted dimensions. MIT licensed.
+
 ## 📘 Learning & Knowledge  
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.  
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.


### PR DESCRIPTION
Adds buyer-eval to the Writing & Research section.

buyer-eval is an MIT-licensed Claude skill for structured B2B vendor evaluation. It interrogates vendor AI agents, cross-references claims against independent sources, and scores across 7 weighted dimensions.

- Repo: https://github.com/salespeak-ai/buyer-eval-skill
- Live gallery: https://eval.salespeak.ai/buyer-eval
- 55+ GitHub stars, 27 published evaluations