### PR TITLE
Add govbridge-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@
 - [AlterLab-Academic-Skills](https://github.com/AlterLab-IEU/AlterLab-Academic-Skills) - 186+ academic research skills across 13 domains for higher education and research.
 - [AlterLab_GameForge](https://github.com/AlterLab-IEU/AlterLab_GameForge) - 34 game development skills covering design, mechanics, and production pipelines.
 - [Claude Code SDK](https://github.com/SeifBenayed/claude-code-sdk) - Open-source, provider-agnostic CLI for AI agents. 13 providers, built-in tools, skill marketplace.
+- [govbridge-skills](https://github.com/michaelmunozjr-blip/govbridge-skills) - 14 government contracting skills covering SAM.gov, certifications,
+  grants, and procurement strategy. MIT licensed.
 
 
 ## 🤝 Contribution


### PR DESCRIPTION
Adds govbridge-skills to the Collections section — a free, open library of 14 Claude Code skills for small businesses navigating government contracting, certifications, SAM.gov registration, and funding programs. MIT licensed.