### PR TITLE
Add idea-os to Collaboration & Project Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@
 - [pm-skills](https://github.com/product-on-purpose/pm-skills) - 24 product management skills across the Triple Diamond lifecycle with agentskills.io spec compliance, templates, and MCP server support.
 - [Product-Manager-Skills](https://github.com/deanpeters/Product-Manager-Skills) - Product management skill library covering discovery, prioritization, PRDs, roadmap planning, and SaaS metrics.
 - [product-manager-skills](https://github.com/Digidai/product-manager-skills) - Senior PM agent with 6 knowledge domains, 12 templates, and 30+ frameworks covering discovery, strategy, delivery, SaaS metrics, PM career coaching (IC to CPO), and AI product craft.
+- [idea-os](https://github.com/Slashworks-biz/idea-os) - Five-phase pipeline (triage → clarify → research → PRD → plan) writing four linked files: clarifying questions, deep research (TAM/SAM/SOM, SWOT, JTBD, competitors, distribution), a PRD with non-goals and metrics, and a phased execution plan with mermaid user journey, stack matrix, and per-phase kill criteria.
 - [cup](https://github.com/krodak/clickup-cli) - ClickUp CLI for AI agents and humans. 40+ commands for tasks, sprints, time tracking. Ships as a Claude Code plugin.
 
 


### PR DESCRIPTION
Adds [idea-os](https://github.com/Slashworks-biz/idea-os) — a Claude Code skill — under the 🤝 Collaboration & Project Management section, next to the existing PM skills (pm-skills, Product-Manager-Skills, product-manager-skills).

### What it does
Five-phase pipeline (triage → clarify → research → PRD → plan) that writes four linked files from a raw idea: clarifying questions, deep market/competitor research, a PRD with non-goals and metrics, and a phased execution plan with mermaid user journey and kill criteria per phase.

### How it differs from existing PM entries
- pm-skills / Product-Manager-Skills are skill *libraries* (24 / 46 individual skills each). idea-os is a *single sequential pipeline* that chains phases so each feeds the next.
- Sibling, not replacement — you can have both installed.

### Example output
Dog-food run on an AI JEE-prep app (India test-prep market) at `examples/jee-prep/`: 4 files, 778 lines, every factual claim sourced or flagged `[assumption]`.

MIT licensed. Repo: https://github.com/Slashworks-biz/idea-os