### PR TITLE
Add Imprint: portable AI collaboration profile (1 skill → 11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@
 ## 🔧 Utility & Automation  
 - [file-organizer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/file-organizer) - Intelligently organizes your files and folders across your computer.
 - [invoice-organizer](https://github.com/ComposioHQ/awesome-claude-skills/blob/master/invoice-organizer/SKILL.md) - Automatically organizes invoices and receipts for tax preparation
+- [Imprint](https://github.com/ilang-ai/Imprint) - Your habits, imprinted on AI. One skill replaces eleven: memory, compression, onboarding, code review, debugging, planning, progress tracking, testing, git workflow, SEO, and copywriting. Portable profile across 19 agents.
 - [skill-creator](https://github.com/anthropics/skills/tree/main/skills/skill-creator) - Template / helper to build new Claude skills.  
 - [template-skill](https://github.com/anthropics/skills/tree/main/template) - Minimal skeleton for a new skill project structure.
 - [agentfund-mcp](https://github.com/RioTheGreat-ai/agentfund-mcp) - Crowdfunding for AI agents. Milestone-based escrow on Base chain for proposals, project tracking, and payments.


### PR DESCRIPTION
Adds Imprint, a single skill that replaces 11 specialized skills by creating a portable user profile.

- MIT licensed, no external API calls, no SaaS dependency
- Works across Claude Code, Codex, Cursor, Copilot, Gemini, Windsurf, Trae, Cline, Roo + 10 more
- Profile stored as plain text under 500 tokens
- Live on skills.sh, VS Code Marketplace, Open VSX, Gemini CLI Gallery
- GitHub: https://github.com/ilang-ai/Imprint