### PR TITLE
Add planmysaas to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@
 - [Emblem AI Agent Wallet](https://github.com/EmblemCompany/Agent-skills/tree/main/skills/emblem-ai-agent-wallet) - Multi-chain crypto wallet management across 7 blockchains (Solana, Ethereum, Base, BSC, Polygon, Hedera, Bitcoin), swaps and transfers.
 - [unity-agent-skills](https://github.com/jahro-console/unity-agent-skills) - Agent skills set for AI-assisted Unity debugging — structured logging, runtime commands, variable watching, and more.
 - [spartan-ai-toolkit](https://github.com/spartan-stratos/spartan-ai-toolkit) - Engineering workflow commands with quality gates, TDD enforcement, and atomic commits for AI coding agents.
+- [planmysaas](https://github.com/creationskiro/planmysaas-claude-skill) - Turns idea to a complete 8-stage SaaS blueprint (idea, research, analysis, architecture, features, frontend, phases, build playbook). Stage 8 ships a decision-grade, rubric-graded build playbook with dependency-ordered steps for Claude Code.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
## Skill: planmysaas

**Repo:** https://github.com/creationskiro/planmysaas-claude-skill
**License:** MIT · **Release:** v1.0.0

### What it does
Turns a one-line idea into a complete 8-stage SaaS blueprint:

1. Idea refine
2. Research
3. Analysis (PMF, SWOT, TAM/SAM/SOM, Porter's 5F, BMC, GTM)
4. Architecture
5. Features
6. Frontend
7. Phases
8. Decision-grade build playbook (rubric-graded, dependency-ordered, leaf to root)

Stage 8 is the differentiator — instead of generic checklists, it produces 9–12 build steps each with goal, inputs, outputs, an 8–14 box acceptance rubric, edge cases, common pitfalls, quality bar, and a stop-and-review gate.

### Install
```bash
git clone https://github.com/creationskiro/planmysaas-claude-skill ~/.claude/skills/planmysaas
```

Then `/planmysaas "<your idea>"` from inside Claude Code.

### Why this list
Plain markdown skill, no build step, MIT licensed, 0 dependencies. Slots into Development & Code Tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)