### PR TITLE
Add OpenRegistry skillpack — 10 Claude skills for live company-registry data (27 countries)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@
 
 ## 📊 Data & Analysis
 - [csv-data-summarizer-claude-skill](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSVs: columns, distributions, missing data, correlations.
+
+- [sophymarine/openregistry](https://github.com/sophymarine/openregistry) — **OpenRegistry skillpack: 10 Claude Agent Skills for live company-registry data across 27 national government registries.** Unmodified, source-linked responses. Cross-border UBO chain walking in a single prompt. Flagship: Cross-Border UBO Chain Walker (walk UK Ltd → LU SARL → KY LP → individual). Free anonymous tier on hosted MCP at openregistry.sophymarine.com/mcp.
 - [notebooklm](https://github.com/sanjay3290/ai-skills/tree/main/skills/notebooklm) - Query and manage Google NotebookLM notebooks with persistent auth, batch/multi queries, source sync, and structured exports.
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security.
 - [mysql](https://github.com/sanjay3290/ai-skills/tree/main/skills/mysql) - Safe read-only SQL queries against MySQL databases.


### PR DESCRIPTION
## What

Adds the [**sophymarine/openregistry**](https://github.com/sophymarine/openregistry) skillpack — 10 Claude Agent Skills for live, direct-to-government company-registry data.

## Why it fits

OpenRegistry is a remote MCP server that connects Claude agents directly to 27 national company registries (UK Companies House, France RNE, Germany Handelsregister, Korea OpenDART, Canada CBCA, 10 US states, Italy, Cayman CIMA, and more). Every response is unmodified — the registry's own field names + raw filing bytes returned verbatim, with source identifiers preserved.

The 10 skills cover: KYC & Cross-Border Due Diligence, **Cross-Border UBO Chain Walker** (flagship), Director Search & PEP Screening, Live Company Accounts & XBRL, Corporate Filing Monitor, Global Company Name Availability, Industry & Competitor Search, Shell Company Detector, Phoenix Company Radar, Sector Gatekeeper List.

## Live demo

Ran the UBO Chain Walker on Revolut Ltd (UK Companies House 08804411) — in ~1.2 seconds Claude ran four live queries to Companies House and returned the 2022-04-29 corporate restructure that passed 75-100% control to Revolut Group Holdings Ltd, then walked to the individual controller Mr Nikolay Storonskiy (British, England-resident, 25-50% shares + right to appoint directors). Even the spelling variation `Storonsky` / `Storonskiy` between 2016 and 2020 filings is preserved verbatim.

Every fact verifiable at https://find-and-update.company-information.service.gov.uk/company/08804411/persons-with-significant-control.

## Install

```bash
git clone https://github.com/sophymarine/openregistry
cp -r openregistry/skills/* ~/.claude/skills/

claude mcp add --transport http OpenRegistry https://openregistry.sophymarine.com/mcp
```

## Also published

- Official MCP Registry: `io.github.sophymarine/openregistry`
- MCP.so: https://mcp.so/server/openregistry

Licence: CC-BY-4.0.