### PR TITLE
Add Claude Skills to Collections (245 skills, 14 domains)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@
 - [AlterLab-Academic-Skills](https://github.com/AlterLab-IEU/AlterLab-Academic-Skills) - 186+ academic research skills across 13 domains for higher education and research.
 - [AlterLab_GameForge](https://github.com/AlterLab-IEU/AlterLab_GameForge) - 34 game development skills covering design, mechanics, and production pipelines.
 - [Claude Code SDK](https://github.com/SeifBenayed/claude-code-sdk) - Open-source, provider-agnostic CLI for AI agents. 13 providers, built-in tools, skill marketplace.
+- [Claude Skills](https://github.com/borghei/Claude-Skills) - 245 production AI skills across 14 domains covering engineering, compliance (18 frameworks incl. ISO 13485, MDR, FDA, EU AI Act, NIS2, DORA, SOC 2, GDPR), C-suite advisory, marketing, legal and finance. Works across 11 AI assistants via `npx @borghei/claude-skills`.
 
 
 ## 🤝 Contribution


### PR DESCRIPTION
Adds **Claude Skills** to the Collections section.

## What it is

245 production-ready AI skills across 14 domains. Strong coverage of roles that other libraries underserve: Marketing (38), C-Level (26), Compliance (21), Legal (17), Product Management (13).

## What's differentiated

- **18 compliance frameworks built in** — SOC 2, ISO 27001, GDPR, HIPAA, EU AI Act, NIS2, DORA, ISO 13485, MDR, FDA and more. This is the only OSS skills library covering regulated industries at production depth.
- **11 AI assistants supported** — Claude Code, Cursor, Codex, Gemini CLI, Copilot, Windsurf, Cline, Aider, Goose, OpenCode, plus ChatGPT/Claude.ai via copy-paste.
- **One-command install** — `npx @borghei/claude-skills add senior-fullstack` auto-detects the target AI assistant and installs the skill into the right directory.
- **5 curated plugin bundles** for Claude Code: engineering-skills, compliance-skills, c-level-skills, marketing-skills, product-skills.

## License

MIT + Commons Clause. Free for personal, education and internal business use.

Link: https://github.com/borghei/Claude-Skills