### PR TITLE
Add claude-vpn-skill to Security & Web Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@
 - [sanitize](https://github.com/openclaw/skills/tree/main/skills/agentward-ai/sanitize) - Detect and redact PII from text files — 15 categories (SSNs, credit cards, API keys, etc.), zero dependencies, all processing local.
 - [webapp-testing](https://github.com/anthropics/skills/tree/main/skills/webapp-testing) - Toolkit for interacting with and testing local web applications using Playwright.
 - [ironclaw-agent-guard](https://github.com/wd041216-bit/ironclaw-agent-guard) - Security review skill and CLI/MCP companion for risky tool calls, prompt injection, secret redaction, and audit-friendly agent workflows.
+- [claude-vpn-skill](https://github.com/henrywen98/claude-vpn-skill) - Deploy a self-hosted anti-censorship VPN on a fresh VPS (VLESS + XHTTP + TLS + Cloudflare CDN via 3X-UI). Handles fresh deploy, certificate renewal, adding users, troubleshooting. An anti-detection alternative to WireGuard / OpenVPN / Shadowsocks / Trojan when the goal is bypassing the GFW.
 
 
 


### PR DESCRIPTION
## What

Adds [claude-vpn-skill](https://github.com/henrywen98/claude-vpn-skill) to the **Security & Web Testing** section.

## Description

A Claude Code skill that deploys a self-hosted anti-censorship VPN on a fresh VPS:
- **Stack**: VLESS + XHTTP + TLS + Cloudflare CDN, managed via 3X-UI panel
- **Capabilities**: fresh deploy, certificate renewal, adding clients, Xray debugging, troubleshooting
- **Positioning**: anti-detection alternative to WireGuard / OpenVPN / Shadowsocks / Trojan when the goal is bypassing strict network censorship

## Why this section

Anti-censorship + network-traffic obfuscation fits "Security & Web Testing" better than "Utility" — the skill's value prop is bypassing detection, not just convenience. Happy to move to Utility & Automation if you'd prefer.

## Quality checklist

- ✅ Public MIT-licensed repo
- ✅ Bilingual README (Chinese + English) with When-to-use, FAQ, security design sections
- ✅ Valid `SKILL.md` frontmatter with rich `description` for AI activation
- ✅ Progressive disclosure — main flow in SKILL.md, deep references in `references/`
- ✅ Released as v4.2

Thanks for maintaining this list!