### PR TITLE
Add bro — propose new 🧠 Memory & Context section

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   - [🔬 Scientific \& Research Tools](#-scientific--research-tools)
   - [✍️ Writing \& Research](#️-writing--research)
   - [📘 Learning \& Knowledge](#-learning--knowledge)
+  - [🧠 Memory & Context](#-memory--context)
   - [🎬 Media \& Content](#-media--content)
   - [🏥 Health \& Life Sciences](#-health--life-sciences)
   - [🤝 Collaboration \& Project Management](#-collaboration--project-management)
@@ -107,6 +108,9 @@
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 
 
+## 🧠 Memory & Context
+- [bro](https://github.com/balaka/bro) — Session continuity memory. Captures mood, vocabulary, decisions, and rules so context survives `/compact` resets. One folder per work thread, weekly auto-update check.
+- 
 
 ## 🎬 Media & Content
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.


### PR DESCRIPTION
## Adding: bro

Repo: https://github.com/balaka/bro

**What it is:** Session continuity memory for Claude Desktop. Captures 
conversation state (mood, vocabulary, decisions, rejected options, 
design/code/investigation context, working-discipline rules) in a daily 
markdown file per work thread, so context survives `/compact` resets.

## Why a new section?

Looking through the list I noticed there's no home for memory/context/
continuity tooling. `review-claudemd` (in Utility) is the closest, but 
that's for reviewing CLAUDE.md — not for preserving session state.

As `/compact` becomes a more common pattern and Claude users accumulate 
skills that specifically address **cross-session memory**, a dedicated 
section seems useful. Proposing 🧠 Memory & Context. bro can be the 
first entry; others will likely follow.

## Compromise

If you'd prefer not to start a new section with just one entry, I'm 
happy to move bro under 🔧 Utility & Automation instead — just let me 
know and I'll update the PR.

## About bro

- One-liner curl install, no build step, pure markdown
- Folder-per-thread layout (parallel work streams don't collide)
- Self-updating via weekly GitHub check
- 4 real-world examples in README
- MIT licensed, single maintainer

Thanks for maintaining this list!