### PR TITLE
Add claude-persona to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@
 - [coinpaprika-api](https://github.com/coinpaprika/skills/tree/main/coinpaprika-api) - Crypto market data for 12K+ coins, 350+ exchanges, tickers, OHLCV, historical prices. Free, no API key.
 - [dexpaprika-api](https://github.com/coinpaprika/skills/tree/main/dexpaprika-api) - Free DEX data across 34 chains: 30M+ pools, 27M+ tokens, real-time SSE streaming, OHLCV. No API key, no rate limits.
 - [gh-star-history](https://github.com/ykdojo/gh-star-history) - Visualize and compare GitHub star history as interactive charts, with regional breakdown of stargazers.
+- [claude-persona](https://github.com/takechanman1228/claude-persona) - Build AI persona panels for customer research. Generates diverse personas, runs agent-separated interviews and concept tests, and delivers executive reports with themes, cross-tabs, and charts.
 
 
 ## 🔬 Scientific & Research Tools


### PR DESCRIPTION
## Summary

Adding [claude-persona](https://github.com/takechanman1228/claude-persona) to the Data & Analysis section.

Claude Code skill (inspired by [TinyTroupe](https://github.com/microsoft/TinyTroupe)) that builds AI persona panels and pressure-tests product concepts before spending on fieldwork.

**What it generates:**
- Reusable persona panels with diverse demographics, Big Five traits, and segment balance (`/persona generate`)
- Open-ended customer interviews for motivations, barriers, and language (`/persona ask`)
- Structured concept tests comparing messages, offers, or features (`/persona concept-test`)
- Executive research reports with theme synthesis, cross-tabs, charts, and verbatims
- Agent-separated simulation (each persona runs in its own `claude -p` subprocess for independent responses)

**Install:**
```
/plugin marketplace add takechanman1228/claude-persona
/plugin install claude-persona@claude-persona
```

Or via curl:
```
curl -fsSL https://raw.githubusercontent.com/takechanman1228/claude-persona/main/install.sh | bash
```

**License:** MIT