### PR TITLE
Add Claude Skills to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@
 
 ## 🗂️ Collections
 
+- [claude-skills](https://github.com/megabytespace/claude-skills) - 14-category autonomous product-building OS with 57 skills and 18 agents. One-line prompts to deployed products on Cloudflare Workers. Covers architecture, build loops, deploy verification, AI visual QA, TDD, SEO, brand systems, and auto-learning. Stack: CF Workers+Hono, Angular+Ionic+PrimeNG, D1/Neon, Drizzle, Clerk, Stripe, Inngest, Resend, Bun, Playwright.
 - [@clawfu/mcp-skills](https://github.com/guia-matthieu/clawfu-skills) - 169 expert-sourced marketing skills (Dunford, Schwartz, Ogilvy, Cialdini) as MCP server with brand memory.
 - [wondelai/skills](https://github.com/wondelai/skills) - 25 agent skills for UX design, marketing/CRO, sales, product strategy, and growth based on books by Norman, Cialdini, Ries, Hormozi, and others.
 - [devmarketing-skills](https://github.com/jonathimer/devmarketing-skills) - 33 skills for developer marketing — HN strategy, technical tutorials, docs-as-marketing, Reddit engagement, developer onboarding, newsletters, and SEO for devtools.


### PR DESCRIPTION
Adds [Claude Skills](https://github.com/megabytespace/claude-skills) to the **Collections** section.\n\n**What it is:** A 14-category autonomous product-building OS with 57 skills and 18 agents. One-line prompts to deployed products on Cloudflare Workers.\n\n**Categories:** OS policy, project briefs, planning/research, memory, architecture, build loops, quality/verification, deploy/runtime, brand/content, experience/design, motion/interaction, media orchestration, observability/growth, independent idea engine.\n\n**Stack:** CF Workers+Hono, Angular+Ionic+PrimeNG, D1/Neon, Drizzle, Clerk, Stripe, Inngest, Resend, Bun, Playwright.\n\nEntry follows the existing format: `- [name](url) - Description.`