### PR TITLE
Add enigmagent-mcp to Security & Web Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@
 ## 🛡 Security & Web Testing
 - [VibeSec-Skill](https://github.com/BehiSecc/VibeSec-Skill) - VibeSec helps Claude write secure code and prevent common vulnerabilities.
 - [defense-in-depth](https://github.com/obra/superpowers/blob/main/skills/defense-in-depth) - Implement multi-layered testing and security best practices.
+- [enigmagent-mcp](https://github.com/Agnuxo1/enigmagent-mcp) - Local encrypted vault MCP server for Claude. AES-256-GCM + Argon2id, zero cloud, zero telemetry. Run with `npx enigmagent-mcp`.
 - [ffuf_claude_skill](https://github.com/jthack/ffuf_claude_skill) - Integrate Claude with FFUF (fuzzing) and analyze results for vulnerabilities.
 - [owasp-security](https://github.com/agamm/claude-code-owasp) - OWASP Top 10:2025, ASVS 5.0, and Agentic AI security (2026) with code review checklists, secure patterns, and language-specific quirks for 20+ languages.
 - [systematic-debugging](https://github.com/obra/superpowers/blob/main/skills/systematic-debugging) - Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes


### PR DESCRIPTION
Adds [**enigmagent-mcp**](https://github.com/Agnuxo1/enigmagent-mcp) under **🛡 Security & Web Testing**.

Local encrypted vault MCP server for Claude:
- AES-256-GCM authenticated encryption + Argon2id KDF
- Zero cloud, zero telemetry — vault stays on the user's machine
- One-line install: `npx enigmagent-mcp`
- MIT, [npm package](https://www.npmjs.com/package/enigmagent-mcp), [Glama security A](https://glama.ai/mcp/servers/Agnuxo1/enigmagent-mcp)

Single-line addition placed alphabetically.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>