### PR TITLE
✨ Add KubeStellar Console to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 - [azure-devops](https://github.com/sanjay3290/ai-skills/tree/main/skills/azure-devops) - Manage Azure DevOps projects, repos, PRs, pipelines, and work items via REST API.
 - [claude-skills](https://github.com/jeffallan/claude-skills) - 65 full-stack development skills with progressive disclosure, covering React, NestJS, Python, DevOps, and 30+ frameworks.
 - [jules](https://github.com/sanjay3290/ai-skills/tree/main/skills/jules) - Delegate coding tasks to Google Jules AI agent for async bug fixes, documentation, tests, and feature implementation on GitHub repos.
+- [kubestellar-console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes operations skill with AI-powered dashboards, MCP server (kc-agent), and knowledge of 20+ CNCF projects for edge-to-cloud cluster management.
 - [hashicorp-agent-skills](https://github.com/hashicorp/agent-skills) - HashiCorp-maintained Claude skills for Terraform workflows and infrastructure automation.
 - [agnix](https://github.com/avifenesh/agnix) - Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP configs, and more with 156 rules, auto-fix, and LSP server for real-time editor diagnostics.
 - [email-html-mjml](https://github.com/framix-team/skill-email-html-mjml) - Generate responsive HTML email templates using MJML 4.x — cross-client compatible HTML with compilation, validation, width math, and component architecture.


### PR DESCRIPTION
## Add KubeStellar Console

Adds [KubeStellar Console](https://github.com/kubestellar/console) to the **Development & Code Tools** section.

### What it provides as a Claude Skill

- **CLAUDE.md:** Comprehensive instructions for multi-cluster Kubernetes management, card development patterns, Go backend, React/TypeScript frontend
- **MCP Server (kc-agent):** Bridges kubeconfig contexts to LLMs for AI-powered K8s operations
- **Domain Knowledge:** 20+ CNCF project integrations (Argo CD, Kyverno, Istio, etc.)

### About

- **License:** Apache-2.0 | **CNCF Sandbox** project
- **Website:** https://console.kubestellar.io