### PR TITLE
Add tianluo: methodology skill for multi-hour autonomous Claude Code runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@
 - [review-claudemd](https://github.com/ykdojo/claude-code-tips/tree/main/skills/review-claudemd) - Review recent conversations to find improvements for CLAUDE.md files.
 - [hubspot-admin-skills](https://github.com/TomGranot/hubspot-admin-skills) - Skills for auditing, cleaning, enriching, and automating HubSpot CRM. Full audit → plan → execute → maintain workflow.
 - [SkillCheck-Free](https://github.com/olgasafonova/SkillCheck-Free) - Free SKILL.md validator with 30+ checks across structure, naming, and semantics. Catches common errors before deploying Claude Code skills.
+- [tianluo](https://github.com/yeewangcn/tianluo) - Methodology skill for multi-hour to multi-day autonomous Claude Code runs. Persistent state across context compactions, plan-time fork enumeration (zero mid-run interruptions), 5-layer failure diagnosis, budget-bounded retry with escalation ladder, file-role separation. For any cron-driven multi-stage task: batch jobs, build/deploy pipelines, parameter sweeps, monitoring runs, long CI.
 
 ## 📰 Articles & Blog Posts
 


### PR DESCRIPTION
Adds **tianluo (田螺姑娘)** — a methodology skill for keeping Claude Code on a multi-hour task without it pinging the operator at 3am for routine confirmations.

Five concrete capabilities, each inverting a specific multi-hour-agent failure mode:

1. **Persistent state survives context compaction** — `state.json` on shared storage; cron prompts rebuild context from scratch every wake-up
2. **Plan-time fork enumeration** — every future user-decision listed as Q1..Qn before the run starts, answered once, then zero further interruptions
3. **5-layer structured diagnosis** — scheduler / container / log / progress / output; never decide "stuck" from one signal
4. **Budget-bounded retry with escalation ladder** — transient → patch → replan → human; never infinite retry, never retry a code-level bug
5. **File-role strict separation** — state.json (machine, JSON), plan.md (human, frozen), failures/*.md (postmortem), memory/*.md (cross-session)

Repo: https://github.com/yeewangcn/tianluo
License: MIT
Bilingual EN/CN README and case study.

Adding under **🔧 Utility & Automation** since the skill applies to any cron-driven multi-stage task — batch jobs, build/deploy pipelines, parameter sweeps, monitoring runs, long CI suites. The example domain in the case study (an ML training pipeline) is incidental; the methodology speaks in fully generic terms.