### PR TITLE
Add solo-skills under Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@
 - [AlterLab-Academic-Skills](https://github.com/AlterLab-IEU/AlterLab-Academic-Skills) - 186+ academic research skills across 13 domains for higher education and research.
 - [AlterLab_GameForge](https://github.com/AlterLab-IEU/AlterLab_GameForge) - 34 game development skills covering design, mechanics, and production pipelines.
 - [Claude Code SDK](https://github.com/SeifBenayed/claude-code-sdk) - Open-source, provider-agnostic CLI for AI agents. 13 providers, built-in tools, skill marketplace.
+- [solo-skills](https://github.com/rockscy/solo-skills) - 7 bilingual (EN+中文) Claude Code skills for solo founders and indie devs: launch tweets, customer emails, decision frameworks, postmortems. Each skill includes an explicit "When NOT to use" section and a worked input/output example.
 
 
 ## 🤝 Contribution


### PR DESCRIPTION
Adding [solo-skills](https://github.com/rockscy/solo-skills) — a bilingual (EN + 中文) Claude Code skills pack for solo founders and indie developers.

### What it contains

Seven skills, each shaped for tasks a solo dev does often and badly:

- `ship-decision` — regret-minimizing call between 2-3 product options
- `launch-tweet` — draft launch tweet/thread, no marketing hype
- `changelog-from-commits` — git log → user-facing release notes
- `bug-from-user` — vague customer email → reproducible bug report
- `standup-solo` — 5-minute personal standup
- `email-customer` — polite-but-firm reply to refunds, scope creep, complaints
- `postmortem-solo` — ≤350-word blame-free postmortem template

### Distinguishing features

- Every skill has a mandatory "When NOT to use" section.
- Every skill has a fixed output format (table or structured sections).
- Every skill has a worked input/output example.
- Bilingual: parallel English and 中文 sections in every `SKILL.md`.
- MIT licensed, one-line installer.

### Where I added it

Under "🗂️ Collections", appended to the end of the existing list.

Repo: https://github.com/rockscy/solo-skills