### PR TITLE
Add gorilla-lead-finder under Utility & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@
 - [review-claudemd](https://github.com/ykdojo/claude-code-tips/tree/main/skills/review-claudemd) - Review recent conversations to find improvements for CLAUDE.md files.
 - [hubspot-admin-skills](https://github.com/TomGranot/hubspot-admin-skills) - Skills for auditing, cleaning, enriching, and automating HubSpot CRM. Full audit → plan → execute → maintain workflow.
 - [SkillCheck-Free](https://github.com/olgasafonova/SkillCheck-Free) - Free SKILL.md validator with 30+ checks across structure, naming, and semantics. Catches common errors before deploying Claude Code skills.
+- [gorilla-lead-finder](https://github.com/opusforge/gorilla-mcp/tree/main/skills/gorilla-lead-finder) - Drives Gorilla's MCP server end-to-end to find a SaaS founder's first users on Reddit, X, YouTube, and TikTok. Refines the idea, ranks posts by buying intent, and drafts platform-tuned outreach.
 
 ## 📰 Articles & Blog Posts
 


### PR DESCRIPTION
Adds the gorilla-lead-finder skill.

Drives the Gorilla MCP server through the full lead-discovery flow: refine the idea, search Reddit/X/YouTube/TikTok, rank posts by buying intent, draft platform-tuned outreach, and produce a Week-1 send cadence. Built so a founder can go from "I just shipped" to "10 messages out before lunch" in one prompt.

Backed by https://usegorilla.app. Paid per run ($0.99 / $3.99 weekly / $149.99 lifetime).

Skill: https://github.com/opusforge/gorilla-mcp/tree/main/skills/gorilla-lead-finder
MCP server: https://github.com/opusforge/gorilla-mcp