### PR TITLE
Add taprun (Claude Code skills marketplace) to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@
 - [AlterLab-Academic-Skills](https://github.com/AlterLab-IEU/AlterLab-Academic-Skills) - 186+ academic research skills across 13 domains for higher education and research.
 - [AlterLab_GameForge](https://github.com/AlterLab-IEU/AlterLab_GameForge) - 34 game development skills covering design, mechanics, and production pipelines.
 - [Claude Code SDK](https://github.com/SeifBenayed/claude-code-sdk) - Open-source, provider-agnostic CLI for AI agents. 13 providers, built-in tools, skill marketplace.
+- [taprun](https://github.com/LeonTing1010/taprun) - 8 first-principles engineering methodology skills: verification gates, plan writing, semi-autonomous task execution, demand archaeology, constraint-driven development, engineering philosophy, and first-principle audit.
 
 
 ## 🤝 Contribution


### PR DESCRIPTION
## Summary

Adds **[taprun](https://github.com/LeonTing1010/taprun)** — a Claude Code skills marketplace with 8 first-principles engineering methodology skills — to the **Collections** section.

## What it is

- 8 skills under `/taprun:` namespace: `verify`, `writing-plans`, `run-task`, `demand-archaeologist`, `constraint-driven-development`, `engineering-philosophy`, `first-principle-audit`, `jimeng-generator`
- Public MIT
- Installation: `claude plugin marketplace add LeonTing1010/taprun && claude plugin install taprun@tap`