### PR TITLE
Add agenttrace session audit skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
 - [jules](https://github.com/sanjay3290/ai-skills/tree/main/skills/jules) - Delegate coding tasks to Google Jules AI agent for async bug fixes, documentation, tests, and feature implementation on GitHub repos.
 - [hashicorp-agent-skills](https://github.com/hashicorp/agent-skills) - HashiCorp-maintained Claude skills for Terraform workflows and infrastructure automation.
 - [agnix](https://github.com/avifenesh/agnix) - Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP configs, and more with 156 rules, auto-fix, and LSP server for real-time editor diagnostics.
+- [agenttrace-session-audit](https://github.com/luoyuctl/agenttrace/tree/master/skills/agenttrace-session-audit) - Audit local AI coding agent sessions for cost, tokens, failures, latency, anomalies, health, diffs, and CI gates.
 - [email-html-mjml](https://github.com/framix-team/skill-email-html-mjml) - Generate responsive HTML email templates using MJML 4.x — cross-client compatible HTML with compilation, validation, width math, and component architecture.
 - [agent-cards-skill](https://github.com/agent-cards/skill) - Manage prepaid virtual Visa cards for AI agents. Create cards, check balances, view credentials, close cards, and get support via MCP tools.
 - [Design Auditor](https://github.com/Ashutos1997/claude-design-auditor-skill) — Audits designs against 17 professional rules: typography, WCAG, spacing, iconography, navigation, tokens + more. Scores out of 100. Supports English & Korean.


### PR DESCRIPTION
## Summary
- Add agenttrace-session-audit to Development & Code Tools.
- Link to the existing skill for auditing local AI coding-agent sessions.

## Why
agenttrace helps Claude Code, Codex CLI, Gemini CLI, Aider, Cursor, and similar users inspect local sessions for cost, token usage, tool failures, latency, anomalies, health, diffs, and CI gates.

## Validation
- `git diff --check`