### PR TITLE
Add iGPT Skills to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@
 - [wondelai/skills](https://github.com/wondelai/skills) - 25 agent skills for UX design, marketing/CRO, sales, product strategy, and growth based on books by Norman, Cialdini, Ries, Hormozi, and others.
 - [devmarketing-skills](https://github.com/jonathimer/devmarketing-skills) - 33 skills for developer marketing — HN strategy, technical tutorials, docs-as-marketing, Reddit engagement, developer onboarding, newsletters, and SEO for devtools.
 - [find-skills](https://github.com/agentbay-ai/agentbay-skills) - Helps users discover, search and install agent skills from the marketplace.
+- [iGPT Skills](https://github.com/igptai/skills) - Email intelligence marketplace for Claude Code, Cowork, Cursor, and any MCP-compatible agent. 13 role-specific plugins (sales, finance, recruiting, CS, executive, procurement, IT, marketing, projects, real estate, consulting, research, HR), 76 skills, and 13 agents. Read-only OAuth, per-user scoping, citations on every answer.
 - [OpenPaw](https://github.com/daxaur/openpaw) - 38-skill bundle that turns Claude Code into a personal assistant. Includes git, Telegram, Discord, Obsidian, daily briefing, and more. Run via `npx pawmode`.
 - [agentskill.sh](https://agentskill.sh) - Browse and install 69,000+ AI agent skills for Claude Code, Cursor, Copilot, Windsurf, Zed, and 20+ AI tools.
 - [Agent Almanac](https://github.com/pjt222/agent-almanac) - 317 skills, 65 agents, and 14 teams for Claude Code following the Agent Skills open standard across 50+ domains.


### PR DESCRIPTION
Adding iGPT Skills, a Claude Code plugin marketplace for email intelligence.

**Repository:** https://github.com/igptai/skills
**Install:** `/plugin marketplace add igptai/skills`
**MCP:** https://mcp.igpt.ai/ (Streamable HTTP, OAuth)
**License:** MIT

13 role-specific plugins (sales, finance, recruiting, customer success, executive, procurement, IT, marketing, projects, real estate, consulting, research, HR) with 76 skills and 13 agents total. Each skill returns schema-validated JSON with citations back to source threads. Read-only OAuth, per-user scoping.

Placed under **🗂️ Collections** since it's a multi-plugin marketplace, similar in shape to OpenPaw, Agent Almanac, and the other Collection entries. Happy to move it elsewhere if a different section fits better.