### PR TITLE
Add production-audit skill (Security & Web Testing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@
 - [sanitize](https://github.com/openclaw/skills/tree/main/skills/agentward-ai/sanitize) - Detect and redact PII from text files — 15 categories (SSNs, credit cards, API keys, etc.), zero dependencies, all processing local.
 - [webapp-testing](https://github.com/anthropics/skills/tree/main/skills/webapp-testing) - Toolkit for interacting with and testing local web applications using Playwright.
 - [ironclaw-agent-guard](https://github.com/wd041216-bit/ironclaw-agent-guard) - Security review skill and CLI/MCP companion for risky tool calls, prompt injection, secret redaction, and audit-friendly agent workflows.
+- [production-audit](https://github.com/commitshow/production-audit) - Audit a shipped repo for the production-readiness gaps that ~70% of AI-coded projects miss (RLS, webhook idempotency, Stripe API idempotency, column GRANT mismatches, secret-in-bundle, etc.). Companion to VibeSec/owasp-security — scans the deployed product post-merge, not the editor buffer.
 
 
 


### PR DESCRIPTION
Adds [\`production-audit\`](https://github.com/commitshow/production-audit) under **Security & Web Testing**.

Audits a shipped repo for the 14 production-readiness gaps ~70% of AI-coded projects miss — RLS coverage, webhook idempotency, Stripe API idempotency, column GRANT mismatches (Postgres column-level grant + new column without grant = silent 42501), secret-in-bundle, mobile input zoom, prompt injection surface, and 7 others.

**Why it complements your existing entries**: VibeSec, owasp-security, defense-in-depth, Trail of Bits — all in-session lenses, scanning the editor buffer at write-time. \`production-audit\` scans the **deployed product** post-merge: live URL, GitHub signals, repo structure, secrets in shipped bundle. Different timing, different inputs, different findings. The two run side-by-side without overlap.

Install: \`npx skills add commitshow/production-audit\` or \`/plugin marketplace add https://github.com/commitshow/production-audit\` inside Claude Code.

Verifications: ✅ valid SKILL.md frontmatter (\`name\` + \`description\` ~390 chars) · ✅ canonical \`.claude/skills/\` layout · ✅ \`.claude-plugin/marketplace.json\` present · ✅ install via \`npx skills add\` confirmed · ✅ MIT license · ✅ README has install + usage + companion-skills sections.