### PR TITLE
Add brag-sheet to Collaboration & Project Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@
 - [Product-Manager-Skills](https://github.com/deanpeters/Product-Manager-Skills) - Product management skill library covering discovery, prioritization, PRDs, roadmap planning, and SaaS metrics.
 - [product-manager-skills](https://github.com/Digidai/product-manager-skills) - Senior PM agent with 6 knowledge domains, 12 templates, and 30+ frameworks covering discovery, strategy, delivery, SaaS metrics, PM career coaching (IC to CPO), and AI product craft.
 - [cup](https://github.com/krodak/clickup-cli) - ClickUp CLI for AI agents and humans. 40+ commands for tasks, sprints, time tracking. Ships as a Claude Code plugin.
+- [brag-sheet](https://github.com/microsoft/copilot-brag-sheet/tree/main/skills/brag-sheet) - Auto-track Copilot/Claude CLI sessions into a structured impact log. Generates performance-review-ready markdown from your work. Zero deps, local-first, MIT.
 
 
 ## 🛡 Security & Web Testing


### PR DESCRIPTION
Adds [microsoft/copilot-brag-sheet](https://github.com/microsoft/copilot-brag-sheet) — an open-source SKILL.md (and bundled Copilot CLI extension) that auto-tracks AI coding sessions into a structured impact log and generates performance-review-ready markdown.

**Why this fits the list:**
- Standard SKILL.md following the agentskills.io spec
- Active project (v1.0.3), MIT licensed, also accepted into [github/awesome-copilot](https://github.com/github/awesome-copilot) (PR #1428)
- Solves a real and recurring pain point: capturing the work you do with AI assistants for performance reviews / OKRs
- Zero dependencies, fully local — no SaaS funnel

Disclosure: PR drafted with help of an AI assistant; project is human-authored and maintained at microsoft/copilot-brag-sheet. Happy to revise format if needed.