### PR TITLE
Add claude-tabletop to Security & Web Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@
 - [sanitize](https://github.com/openclaw/skills/tree/main/skills/agentward-ai/sanitize) - Detect and redact PII from text files — 15 categories (SSNs, credit cards, API keys, etc.), zero dependencies, all processing local.
 - [webapp-testing](https://github.com/anthropics/skills/tree/main/skills/webapp-testing) - Toolkit for interacting with and testing local web applications using Playwright.
 - [ironclaw-agent-guard](https://github.com/wd041216-bit/ironclaw-agent-guard) - Security review skill and CLI/MCP companion for risky tool calls, prompt injection, secret redaction, and audit-friendly agent workflows.
+- [claude-tabletop](https://github.com/cjcsecurity/claude-tabletop) - Paired skills for technical tabletop exercises (ransomware, breach, supply chain, insider threat, zero-day) and blameless After-Action Reports — project-aware scenario picks, interactive HTML runbook with live exercise timer + JSON export, NIST CSF 2.0 / SOC 2 / PCI DSS v4 / ISO 27001:2022 / HIPAA / GDPR / MITRE ATT&CK tagging.
 
 
 


### PR DESCRIPTION
Adds **claude-tabletop** — two paired Claude Code skills for security-domain tabletop exercises and After-Action Report drafting.

- **/tabletop-exercise**: project-aware scenario selection across 9 domains (heavy on cybersec / prodsec / privacy-compliance), interactive HTML runbook with live exercise timer + reveal overlays + JSON export
- **/tabletop-aar**: blameless AAR drafter with audience-tuned register (internal / leadership / regulator / board) and P0/P1/P2 severity rubric
- Compliance framework tagging: NIST CSF 2.0, SOC 2, PCI DSS v4, ISO 27001:2022, HIPAA, GDPR, MITRE ATT&CK
- **Repo**: https://github.com/cjcsecurity/claude-tabletop
- **Live demo**: https://live-demo-zeta-one.vercel.app
- **License**: Apache-2.0

Followed the list's existing format. Happy to adjust placement or wording on review.