### PR TITLE
Add Honeydew: Semantic Layer for AI and BI

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@
 - [coinpaprika-api](https://github.com/coinpaprika/skills/tree/main/coinpaprika-api) - Crypto market data for 12K+ coins, 350+ exchanges, tickers, OHLCV, historical prices. Free, no API key.
 - [dexpaprika-api](https://github.com/coinpaprika/skills/tree/main/dexpaprika-api) - Free DEX data across 34 chains: 30M+ pools, 27M+ tokens, real-time SSE streaming, OHLCV. No API key, no rate limits.
 - [gh-star-history](https://github.com/ykdojo/gh-star-history) - Visualize and compare GitHub star history as interactive charts, with regional breakdown of stargazers.
+- [honeydew-ai-coding-agents-plugins](https://github.com/honeydew-ai/honeydew-ai-coding-agents-plugins) - 11 skills + MCP server for building and querying a governed semantic layer over Snowflake, Databricks, and BigQuery from coding agents (Claude Code, Codex, Cursor, Copilot CLI, Gemini CLI). Same trusted model serves BI tools and AI agents. Plugins are Apache 2.0.
 
 
 ## 🔬 Scientific & Research Tools


### PR DESCRIPTION
Honeydew is a semantic layer that lives in your data warehouse and serves both BI tools and AI agents from the same governed model. The linked honeydew-ai-coding-agents-plugins repo (Apache 2.0) is a multi-vendor marketplace covering Claude Code, Codex, Cursor, GitHub Copilot CLI, Gemini CLI plus raw MCP, with 11 skills (model exploration, entity/ relation/attribute/metric/context/domain creation, validation, query, filtering, workspace branching). Warehouses: Snowflake, Databricks, BigQuery.