### PR TITLE
Add TweetClaw to Utility & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@
 - [task-observer](https://github.com/rebelytics/one-skill-to-rule-them-all) - A meta-skill that builds and improves all your skills, including itself.
 - [glitternetwork/pinme](https://github.com/glitternetwork/skills/tree/main/pinme) - PinMe is a zero-config frontend deployment tool. No servers. No accounts. No setup.
 - [linkedin](https://github.com/Linked-API/linkedin-skills) - General-purpose LinkedIn automation via Linked API — fetch profiles, search people/companies, send messages, manage connections, create posts. Supports Sales Navigator.
+- [TweetClaw](https://github.com/Xquik-dev/tweetclaw) - X/Twitter automation skill and OpenClaw plugin for search tweets, search tweet replies, post tweets, follower export, media workflows, monitors, webhooks, and giveaway draws.
 - [moodtrip-hotel-search](https://github.com/adiny/moodtrip-hotel-search) - Hotel search, comparison, reviews, pricing, and booking handoff via MoodTrip.ai MCP server. 12 tools including semantic search, room matching, and price intelligence.
 - [review-claudemd](https://github.com/ykdojo/claude-code-tips/tree/main/skills/review-claudemd) - Review recent conversations to find improvements for CLAUDE.md files.
 - [hubspot-admin-skills](https://github.com/TomGranot/hubspot-admin-skills) - Skills for auditing, cleaning, enriching, and automating HubSpot CRM. Full audit → plan → execute → maintain workflow.


### PR DESCRIPTION
## Summary

- add TweetClaw to the `Utility & Automation` section
- position it as the automation-oriented companion to the existing `x-twitter-scraper` listing
- keep the wording concrete around the actual jobs users search for

## Why this belongs here

`x-twitter-scraper` already covers the data and analysis side of the Xquik ecosystem in this list.

TweetClaw is a different surface: a packaged X/Twitter automation skill and OpenClaw plugin for agents that need to search tweets, search tweet replies, post tweets, export followers, run media workflows, create monitors, send webhooks, and run giveaway draws.

That makes it a better fit for `Utility & Automation` than `Data & Analysis`.

## Disclosure

I maintain TweetClaw and Xquik.
