### PR TITLE
Add guanyuan-majia (Guandata BI multi-agent skill) to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@
 - [coinpaprika-api](https://github.com/coinpaprika/skills/tree/main/coinpaprika-api) - Crypto market data for 12K+ coins, 350+ exchanges, tickers, OHLCV, historical prices. Free, no API key.
 - [dexpaprika-api](https://github.com/coinpaprika/skills/tree/main/dexpaprika-api) - Free DEX data across 34 chains: 30M+ pools, 27M+ tokens, real-time SSE streaming, OHLCV. No API key, no rate limits.
 - [gh-star-history](https://github.com/ykdojo/gh-star-history) - Visualize and compare GitHub star history as interactive charts, with regional breakdown of stargazers.
+- [guanyuan-majia](https://github.com/maojiebc/guanyuan-majia) - 观远 BI (Guandata) full-stack skill: data query/card creation, ETL governance & rewrite (incl. SmartETL full-chain rewrite + ExecPlan), custom chart HTML/JS injection. 60+ ETL operations battle-tested. Compatible with Claude Code, OpenClaw, Codex, Hermes.
 
 
 ## 🔬 Scientific & Research Tools


### PR DESCRIPTION
## Add `guanyuan-majia` to 📊 Data & Analysis

A multi-agent Skill for **Guandata BI (观远 BI)** — a Chinese enterprise BI platform — covering the full operational lifecycle:

- **Part A** — Data query, card creation, BI HTTP API
- **Part B** — ETL governance, write/delete, SmartETL full-chain rewrite, ExecPlan engineering
- **Part C** — Custom chart HTML/CSS/JS injection + 10-class error handbook

### Highlights
- **60+ real ETL operations** battle-tested in production
- **Methodology contributions** from Guandata's CTO 张进 (Part B-17 SmartETL rewrite + Part C custom chart) and OpenAI Codex (Part B-17.11 ExecPlan spec)
- **Tool-agnostic**: Claude Code · OpenClaw · Codex · Hermes (gbrain) — single SKILL.md, 4 install paths
- **Progressive disclosure** (V1.5.0): SKILL.md router (~48 KB) + 8 reference playbooks loaded on demand
- Published on **ClawHub**: https://clawhub.ai/skills/guanyuan-majia

Repo: https://github.com/maojiebc/guanyuan-majia · License: MIT · Latest: v1.5.2