### PR TITLE
Add 3 audit-first skills (hormozi-offer-audit, cialdini-influence-audit, claude-blog-assistant)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [avoid-ai-writing](https://github.com/conorbronsdon/avoid-ai-writing) - Audits and rewrites content to remove 21 categories of AI writing patterns with a 43-entry replacement table and two-pass detection.
 - [naming](https://github.com/glacierphonk/naming) - Metaphor-driven naming for products, SaaS, brands, bots, and open source projects. Structured process that produces memorable, meaningful names.
+- [hormozi-offer-audit](https://github.com/johnericforte/claude-skill-hormozi-offer-audit) - Audit sales offers (landing pages, pricing tiers, lead magnets) using Alex Hormozi's frameworks from $100M Offers and $100M Leads. Scores Value Equation (4 levers, 0-25 each) + Grand Slam checklist. Returns Top 3 Fixes with before/after.
+- [cialdini-influence-audit](https://github.com/johnericforte/claude-skill-cialdini-influence-audit) - Audit persuasive copy (landing pages, emails, sales sequences) for missing influence principles using Robert Cialdini's seven principles + Pre-Suasion. Scores each principle PRESENT/WEAK/MISSING with anti-overstacking check.
+- [claude-blog-assistant](https://github.com/johnericforte/claude-skill-blog-assistant) - Dual-mode blog publishing assistant. Ship new posts via 8-step lifecycle (brief → write → humanize → SEO → schema → analyze → repurpose) OR retroactively audit existing posts and return prioritized retrofit list. Wraps AgriciDaniel/claude-blog.
 
 
 ## 📘 Learning & Knowledge  


### PR DESCRIPTION
Adds 3 audit-first Claude Code plugins to the Writing & Research section:

- **hormozi-offer-audit** — scored audit of sales offers (landing pages, pricing tiers, lead magnets) using Alex Hormozi's frameworks from \$100M Offers (Value Equation, Grand Slam Offer) and \$100M Leads (lead magnet quality bar). Returns scored audit with prioritized fixes and before/after examples.
- **cialdini-influence-audit** — per-principle audit of persuasive copy (landing pages, emails, sales sequences) using Robert Cialdini's seven influence principles + Pre-Suasion. Scores each principle PRESENT/WEAK/MISSING with anti-overstacking check.
- **claude-blog-assistant** — dual-mode blog publishing assistant that wraps AgriciDaniel/claude-blog into a complete lifecycle. Mode 1 ships a new post via 8 steps. Mode 2 retroactively audits an existing post and returns a prioritized retrofit list.

All three:
- MIT licensed
- Audit-first (not generators)
- Real-search-data backed positioning
- Frameworks cited descriptively under nominative fair use
- Include DISCLAIMER.md for IP transparency
- Plugin format (.claude-plugin/ manifest + skills/<name>/SKILL.md)

Repos:
- https://github.com/johnericforte/claude-skill-hormozi-offer-audit
- https://github.com/johnericforte/claude-skill-cialdini-influence-audit
- https://github.com/johnericforte/claude-skill-blog-assistant

Author: Eric Forte (https://www.ericforte.com)