### PR TITLE
Add buy-me-a-car skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@
 - [review-claudemd](https://github.com/ykdojo/claude-code-tips/tree/main/skills/review-claudemd) - Review recent conversations to find improvements for CLAUDE.md files.
 - [hubspot-admin-skills](https://github.com/TomGranot/hubspot-admin-skills) - Skills for auditing, cleaning, enriching, and automating HubSpot CRM. Full audit → plan → execute → maintain workflow.
 - [SkillCheck-Free](https://github.com/olgasafonova/SkillCheck-Free) - Free SKILL.md validator with 30+ checks across structure, naming, and semantics. Catches common errors before deploying Claude Code skills.
+- [buy-me-a-car](https://github.com/DaizeDong/buy-me-a-car) - End-to-end used-car pre-purchase workflow for Claude Code — multi-site research, mass dealer outreach, Gmail cron monitoring, OTD negotiation with market-data anchors, CARFAX analysis, and dossier PDF generation. Covers all 50 US states + DC. Bilingual English + Chinese.
 
 ## 📰 Articles & Blog Posts
 


### PR DESCRIPTION
## Summary

Adds **buy-me-a-car** to the Utility & Automation section — an end-to-end used-car pre-purchase workflow for Claude Code. It coordinates multi-site research, mass dealer outreach, Gmail cron monitoring, OTD (out-the-door) negotiation anchored on market data, CARFAX analysis, and dossier PDF generation. Coverage spans all 50 US states + DC, with bilingual English + Chinese support.

## Key features

- Multi-site vehicle research and price comparison
- Mass dealer email outreach with templated, region-aware messaging
- Gmail cron-based reply monitoring and parsing
- OTD-price negotiation guidance anchored to live market data
- CARFAX report analysis and risk summarization
- Dossier PDF generation for each candidate vehicle
- All 50 US states + DC coverage
- Bilingual: English and Chinese

## Details

- **Repository:** https://github.com/DaizeDong/buy-me-a-car
- **Author:** @DaizeDong
- **License:** MIT
- **Maintenance:** Actively maintained
- **Status:** Real-world tested

## Category

Placed under **Utility & Automation** alongside similar workflow/automation skills (file-organizer, invoice-organizer, hubspot-admin-skills).

## Test plan

- [x] Verified link resolves to a valid public GitHub repo
- [x] Entry format matches neighboring entries (dash, link, dash, one-line description)
- [x] No duplicate entry exists in README.md
- [x] Only README.md is modified