### PR TITLE
Add ai-investment-skills to Data & Analysis section

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@
 - [coinpaprika-api](https://github.com/coinpaprika/skills/tree/main/coinpaprika-api) - Crypto market data for 12K+ coins, 350+ exchanges, tickers, OHLCV, historical prices. Free, no API key.
 - [dexpaprika-api](https://github.com/coinpaprika/skills/tree/main/dexpaprika-api) - Free DEX data across 34 chains: 30M+ pools, 27M+ tokens, real-time SSE streaming, OHLCV. No API key, no rate limits.
 - [gh-star-history](https://github.com/ykdojo/gh-star-history) - Visualize and compare GitHub star history as interactive charts, with regional breakdown of stargazers.
+- [ai-investment-skills](https://github.com/tellmefrankie/ai-investment-skills) - Six investment analysis skills: options flow scanner with real/lottery call filtering (caught XLI P/C 5.32 anomaly live), news sentiment analyzer (200+ articles to per-ticker score), EV cost calculator, stop-loss price monitor, sector rotation signal, and 9-wave investment briefing agent. TypeScript + Claude API.
 
 
 ## 🔬 Scientific & Research Tools


### PR DESCRIPTION
## What this adds

Adds [ai-investment-skills](https://github.com/tellmefrankie/ai-investment-skills) to the **Data & Analysis** section.

## Skill summary

Six daily skills for individual investors built on Claude Code:

- **Options flow scanner** with lottery-call filtering — strips delta <0.15, premium <$0.10 contracts. Caught CEG raw P/C 1.06 → adjusted 59.2 after filter, revealing hidden bearish pressure
- **Stop-loss & take-profit monitor** — real-time price alerts during pre-market / regular / after-hours via Telegram
- **Earnings risk check** — flags IV crush risk and unusual options activity before earnings
- **Sector rotation signal** — ETF P/C flow across XLI, XLF, XLE, XLK
- **Real-vs-lottery position classifier** — separates institutional flow from retail lottery tickets
- **Daily portfolio briefing** — morning digest via Telegram

Free tier: 3 tickers + options scanner + stop-loss monitor included in the repo.

## Install

```bash
cp options-flow-analyzer/SKILL.md ~/.claude/skills/options-flow-analyzer.md
```