### PR TITLE
Add cn-calendar-skill to Utility & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@
 - [review-claudemd](https://github.com/ykdojo/claude-code-tips/tree/main/skills/review-claudemd) - Review recent conversations to find improvements for CLAUDE.md files.
 - [hubspot-admin-skills](https://github.com/TomGranot/hubspot-admin-skills) - Skills for auditing, cleaning, enriching, and automating HubSpot CRM. Full audit → plan → execute → maintain workflow.
 - [SkillCheck-Free](https://github.com/olgasafonova/SkillCheck-Free) - Free SKILL.md validator with 30+ checks across structure, naming, and semantics. Catches common errors before deploying Claude Code skills.
+- [cn-calendar-skill](https://github.com/demo112/cn-calendar-skill) - China calendar full-stack skill — official PRC public holidays (2004-2026, includes State Council make-up workdays), Gregorian/lunar conversion, 24 solar terms, workday math, and bridge-leave planning. Self-contained, zero external API.
 
 ## 📰 Articles & Blog Posts
 


### PR DESCRIPTION
## What

Adds [`cn-calendar-skill`](https://github.com/demo112/cn-calendar-skill) under **🔧 Utility & Automation**.

## Why it fits

A self-contained China-calendar Skill that solves a recurring pain point for any developer building tools that touch the Chinese market — figuring out workdays, holidays, lunar dates, etc. without depending on a flaky external API or hard-coding holidays every year.

**13 endpoints, all offline:**
- Official PRC State Council holiday data 2004-2026 (incl. 调休 make-up workdays)
- Gregorian to Lunar conversion (1900-2100)
- 24 solar terms (二十四节气)
- `add_workdays(start, n)` for invoice/payment terms and shipping ETAs
- `find_bridge_leaves()` — how many days off can I get for N days of leave
- Zodiac, constellation, next-holiday queries

## Use cases

- HR scheduling: How many workdays in June, when is Dragon Boat Festival?
- E-commerce calendars: When is Mid-Autumn this year, any 调休 around 11.11?
- Finance: Payment due in 30 workdays from invoice — what's the date?
- Logistics: 5 workdays delivery from today — ETA?

## Tech

- Built on top of `chinese-calendar` (国务院 official data) + `zhdate`
- 100% offline, no API key, no network calls
- MIT license
- Compatible with Claude Code, Codex, OpenClaw, and any SKILL.md-aware agent

## Checklist

- [x] Resource is publicly accessible
- [x] Link is valid
- [x] Placed in correct category (🔧 Utility & Automation)
- [x] Description follows existing entry style
- [x] No new section created