### PR TITLE
Add Knack Starter Pack to Utility & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@
 - [review-claudemd](https://github.com/ykdojo/claude-code-tips/tree/main/skills/review-claudemd) - Review recent conversations to find improvements for CLAUDE.md files.
 - [hubspot-admin-skills](https://github.com/TomGranot/hubspot-admin-skills) - Skills for auditing, cleaning, enriching, and automating HubSpot CRM. Full audit → plan → execute → maintain workflow.
 - [SkillCheck-Free](https://github.com/olgasafonova/SkillCheck-Free) - Free SKILL.md validator with 30+ checks across structure, naming, and semantics. Catches common errors before deploying Claude Code skills.
+- [Knack Starter Pack](https://github.com/knack-run/knack-starter-pack) - Two MIT-licensed skills for solo operators. idea-clarifier turns a rough product idea or consulting brief into audience, pain quote, offer framing, and a ranked first-action plan. first-skill-template scaffolds new skills in a canonical body pattern.
 
 ## 📰 Articles & Blog Posts
 


### PR DESCRIPTION
Adds the Knack Starter Pack — two MIT-licensed Claude Code skills for solo operators.

**What it is**
- `idea-clarifier` — turns a rough product idea, consulting brief, or project sketch into audience definition, a pain point in the audience's own words, an offer framing, and a ranked first-action plan. Refuses category audiences and invented specifics.
- `first-skill-template` — scaffolds new skills at `.claude/skills/<name>/SKILL.md` in a canonical body pattern.

**Why Utility & Automation:** sits alongside the existing `skill-creator` and `template-skill` entries; `first-skill-template` is the same shape of meta-skill.

**Verifiable:** the repo is public at https://github.com/knack-run/knack-starter-pack with an installer (`./install.sh`), a worked example, and an MIT licence. No network calls beyond the install script.