### PR TITLE
Add restorative-repair skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [avoid-ai-writing](https://github.com/conorbronsdon/avoid-ai-writing) - Audits and rewrites content to remove 21 categories of AI writing patterns with a 43-entry replacement table and two-pass detection.
 - [naming](https://github.com/glacierphonk/naming) - Metaphor-driven naming for products, SaaS, brands, bots, and open source projects. Structured process that produces memorable, meaningful names.
+- [restorative-repair](https://github.com/MinistaJazz/restorative-repair) - Response-layer repair skill for AI agents that names output errors, offers proportionate repair, routes crisis safely, and avoids apology loops.
 
 
 ## 📘 Learning & Knowledge  


### PR DESCRIPTION
Adds restorative-repair, an external public Claude-compatible skill for response-layer repair when AI agents make output errors.\n\nRepo: https://github.com/MinistaJazz/restorative-repair\n\nThe skill includes trigger taxonomy, severity tiers, crisis suppression rules, bounded loop-exit behavior, and auditable benchmark prompts.