### PR TITLE
Add aave-respect skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@
 
 ## ✍️ Writing & Research
 - [article-extractor](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/article-extractor) - Extract full article text and metadata from web pages.
+- [aave-respect](https://github.com/MinistaJazz/aave-respect) - Respect-layer skill for recognizing African American Vernacular English accurately, preserving meaning, avoiding correction, and preventing mimicry.
 - [content-research-writer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/content-research-writer) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, iterating on outlines, and providing real-time feedback on each section
 - [internal-comms](https://github.com/anthropics/skills/tree/main/skills/internal-comms) - Create internal communications (status reports, leadership updates, 3P updates, company newsletters, FAQs, incident reports, project updates, etc)
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.


### PR DESCRIPTION
Adds aave-respect, an external public Claude-compatible skill for recognizing and respecting African American Vernacular English without correction, flattening, or mimicry.\n\nRepo: https://github.com/MinistaJazz/aave-respect\n\nThe skill includes recognition, response, transcription, editing, generation guidance, red-team prompts, and developer resources for AAVE-aware AI behavior.