### PR TITLE
Add CreatorSkills marketplace to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@
 - [AlterLab-Academic-Skills](https://github.com/AlterLab-IEU/AlterLab-Academic-Skills) - 186+ academic research skills across 13 domains for higher education and research.
 - [AlterLab_GameForge](https://github.com/AlterLab-IEU/AlterLab_GameForge) - 34 game development skills covering design, mechanics, and production pipelines.
 - [Claude Code SDK](https://github.com/SeifBenayed/claude-code-sdk) - Open-source, provider-agnostic CLI for AI agents. 13 providers, built-in tools, skill marketplace.
+- [CreatorSkills](https://creatorskills.co) - Marketplace of AI skills for content creators — YouTubers, podcasters, and course builders. Skills for Claude, ChatGPT, and universal use covering scriptwriting, thumbnails, audience growth, sponsorships, and more.
 
 
 ## 🤝 Contribution


### PR DESCRIPTION
## What does this add?

[CreatorSkills](https://creatorskills.co) is a marketplace of AI skills targeting content creators (YouTubers, podcasters, course builders). It offers skills for Claude, ChatGPT, and universal platforms covering:

- Scriptwriting & outlines
- Thumbnail & title generation
- Audience growth strategies
- Sponsorship & brand deal workflows
- Community engagement
- Course creation

## Why it fits in Collections

CreatorSkills is a curated, growing collection of skills for a specific creator audience — similar to the other marketplace/collection entries already listed. It uniquely targets content creators rather than developers or general business users.

Homepage: https://creatorskills.co