### PR TITLE
Add aomi-transact and aomi-build (crypto agent + SDK scaffolder)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@
 - [lightning-architecture-review](https://github.com/8144225309/superscalar-mcp/tree/master/skills/lightning-architecture-review) - Review Bitcoin Lightning Network protocol designs, compare channel factory approaches, and analyze Layer 2 scaling tradeoffs.
 - [Playwright Skill](https://github.com/testdino-hq/playwright-skill) - AI agent-ready Playwright skill with structured SKILL.md, test automation workflows, and MCP-compatible setup for real-world testing pipelines.
 - [Emblem AI Agent Wallet](https://github.com/EmblemCompany/Agent-skills/tree/main/skills/emblem-ai-agent-wallet) - Multi-chain crypto wallet management across 7 blockchains (Solana, Ethereum, Base, BSC, Polygon, Hedera, Bitcoin), swaps and transfers.
+- [aomi-transact](https://github.com/aomi-labs/skills/tree/main/aomi-transact) - Natural-language crypto agent: turns prompts like "swap 1 ETH for USDC" into fork-simulated, wallet-signed transactions across EVM chains (Ethereum, Base, Arbitrum, Optimism, Polygon, Linea). Non-custodial, account-abstraction first, 40+ DeFi/CEX/perps integrations (Uniswap, Aave, GMX, Polymarket, Hyperliquid).
+- [aomi-build](https://github.com/aomi-labs/skills/tree/main/aomi-build) - Scaffolds Aomi Rust SDK crates from OpenAPI/Swagger specs — generates `lib.rs`/`client.rs`/`tool.rs` plus tool schemas and host-interop flows for building new Aomi protocol integrations.
 - [unity-agent-skills](https://github.com/jahro-console/unity-agent-skills) - Agent skills set for AI-assisted Unity debugging — structured logging, runtime commands, variable watching, and more.
 - [spartan-ai-toolkit](https://github.com/spartan-stratos/spartan-ai-toolkit) - Engineering workflow commands with quality gates, TDD enforcement, and atomic commits for AI coding agents.
 


### PR DESCRIPTION
Adding two skills from [aomi-labs/skills](https://github.com/aomi-labs/skills) under **Development & Code Tools**, next to the existing Emblem AI Agent Wallet peer.

## aomi-transact

Natural-language crypto agent: turns prompts like *"swap 1 ETH for USDC"* into fork-simulated, wallet-signed transactions across EVM chains (Ethereum, Base, Arbitrum, Optimism, Polygon, Linea). Non-custodial throughout — the skill stages calldata and queues a wallet request; the user signs explicitly via `aomi tx sign`. Account-abstraction first (EIP-7702 on Ethereum, ERC-4337 on L2s). 40+ DeFi/CEX/perps integrations (Uniswap, Aave, Lido, GMX, Polymarket, Hyperliquid, Binance, OKX, …).

- Live on [ClawHub](https://clawhub.ai/skills/aomi-transact) and [LobeHub](https://lobehub.com/skills/aomi-labs-aomi-aomi-transact)
- Spec-compliant SKILL.md (133 lines, 7 required body sections + Safety Justification + OWASP AST03 permissions manifest)
- L2 risk tier with scoped Bash + network allowlists

## aomi-build

Companion skill for builders extending Aomi: scaffolds Rust SDK crates (`lib.rs` / `client.rs` / `tool.rs` plus tool schemas, preambles, host-interop flows) from OpenAPI/Swagger specs, SDK docs, or repository examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)