### PR TITLE
Add Bilig WorkPaper skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 - [finishing-a-development-branch](https://github.com/obra/superpowers/tree/main/skills/finishing-a-development-branch) - Guides completion of development work by presenting clear options and handling chosen workflow.
 - [pypict-claude-skill](https://github.com/omkamal/pypict-claude-skill) - Design comprehensive test cases using PICT (Pairwise Independent Combinatorial Testing) for requirements or code, generating optimized test suites with pairwise coverage.
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
+- [Bilig WorkPaper](https://github.com/proompteng/bilig/tree/main/skills/bilig-workpaper) - Formula-backed workbook runtime for agents: edit cells, recalculate, verify readback, and persist WorkPaper JSON.
 - [claude-starter](https://github.com/raintree-technology/claude-starter) - Production-ready Claude Code configuration template with 40 auto-activating skills across 8 domains, TOON format support for 30-60% token savings, and native Zig encoder/decoder.
 - [move-code-quality-skill](https://github.com/1NickPappas/move-code-quality-skill) - Analyzes Move language packages against the official Move Book Code Quality Checklist for Move 2024 Edition compliance and best practices.
 - [oiloil-ui-ux-guide](https://github.com/oil-oil/oiloil-ui-ux-guide) - Modern UI/UX guidance and review skill with `guide` and `review` modes. Covers CRAP, task-first UX, HCI laws, interaction psychology, and modern minimal style.


### PR DESCRIPTION
Adds Bilig WorkPaper to Development & Code Tools.

Bilig gives agents a formula-backed workbook runtime: edit cells, recalculate, verify readback, and persist WorkPaper JSON without driving Excel or Sheets through a UI.

Link verified: https://github.com/proompteng/bilig/tree/main/skills/bilig-workpaper