### PR TITLE
Add pgyer-skill to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@
 - [Emblem AI Agent Wallet](https://github.com/EmblemCompany/Agent-skills/tree/main/skills/emblem-ai-agent-wallet) - Multi-chain crypto wallet management across 7 blockchains (Solana, Ethereum, Base, BSC, Polygon, Hedera, Bitcoin), swaps and transfers.
 - [unity-agent-skills](https://github.com/jahro-console/unity-agent-skills) - Agent skills set for AI-assisted Unity debugging — structured logging, runtime commands, variable watching, and more.
 - [spartan-ai-toolkit](https://github.com/spartan-stratos/spartan-ai-toolkit) - Engineering workflow commands with quality gates, TDD enforcement, and atomic commits for AI coding agents.
+- [pgyer-skill](https://github.com/PGYER/pgyer-skill) - Official skill from PGYER (蒲公英), China's leading mobile app beta-distribution platform (since 2014). Upload iOS / Android / HarmonyOS builds for beta testing; bundles GitHub Actions and GitLab CI templates. Cross-agent via the open Skills CLI; pairs with the official `pgyer-mcp-server`.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
## Summary

Adds **PGYER/pgyer-skill** to the 🛠 Development & Code Tools section.

## What it is

The official Claude Code / agent skill from [PGYER (蒲公英)](https://www.pgyer.com), China's leading mobile app beta-distribution platform. PGYER has operated since **2014** (12+ years) and is used by hundreds of thousands of mobile developers — it is to China what TestFlight / Firebase App Distribution is to the West.

The skill lives in the official \`PGYER/\` GitHub org and pairs with PGYER's existing official MCP server [\`pgyer-mcp-server\`](https://github.com/PGYER/pgyer-mcp-server) (also on npm).

## What the skill does

Triggers when the user mentions PGYER / 蒲公英 / pgyer.com, or asks to upload an \`.ipa\` / \`.apk\` / \`.hap\` for beta testing, fetch install links or QR codes, query a beta app's version history or install counts, manage tester groups, or wire up CI/CD that publishes to PGYER. Covers iOS, Android, and HarmonyOS.

Ships:
- \`SKILL.md\` with YAML frontmatter
- Platform references for iOS / Android / HarmonyOS
- CI/CD templates for GitHub Actions and GitLab CI
- A routing regression battery in \`tests/scenarios.md\`

## Test plan

- [x] Repository link resolves
- [x] Entry follows existing simple format (\`- [name](url) - description\`)
- [x] Placed at end of Development & Code Tools (matching where most recent entries land)