### PR TITLE
Add chmod-777-claude to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@
 - [Emblem AI Agent Wallet](https://github.com/EmblemCompany/Agent-skills/tree/main/skills/emblem-ai-agent-wallet) - Multi-chain crypto wallet management across 7 blockchains (Solana, Ethereum, Base, BSC, Polygon, Hedera, Bitcoin), swaps and transfers.
 - [unity-agent-skills](https://github.com/jahro-console/unity-agent-skills) - Agent skills set for AI-assisted Unity debugging — structured logging, runtime commands, variable watching, and more.
 - [spartan-ai-toolkit](https://github.com/spartan-stratos/spartan-ai-toolkit) - Engineering workflow commands with quality gates, TDD enforcement, and atomic commits for AI coding agents.
+- [chmod-777-claude](https://github.com/JeongWonjae/chmod-777-claude) - Three opinionated root-mode skills for Claude Code: **rootfix** (root-cause debug with WHY×5 drilling), **rootclean** (behavior-preserving refactoring with one-pattern-per-PR), **rootbuild** (pattern-respecting feature additions with mandatory grep + tests). Bilingual triggers (Korean + English).
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
## Adding chmod-777-claude

[chmod-777-claude](https://github.com/JeongWonjae/chmod-777-claude) is a collection of three opinionated root-mode skills for Claude Code.

### The Three Modes

- **rootfix** — Root-cause debugging with WHY×5 drilling, drift/race detection, and trade-off-explicit options
- **rootclean** — Behavior-preserving refactoring with baseline-capture, one-pattern-per-PR discipline, and four-smells detection
- **rootbuild** — Pattern-respecting feature additions with mandatory existing-pattern grep, requirement clarification, and test-coupled implementation

### Why It's Different

Existing debug/refactor skills focus on tools (debuggers, formatters). This one encodes **opinionated workflows** that prevent the three most common failure modes:

1. Symptom-patching instead of root-cause fixing
2. Scope creep during cleanup
3. Ignoring existing patterns when adding features

### Features

- Bilingual (Korean + English) trigger phrases
- Python-focused examples (FastAPI, Lambda, AI/ML)
- 6-step workflows + anti-patterns per mode
- MIT licensed, installer script included

### Checklist

- [x] Added to **🛠 Development & Code Tools** section
- [x] Format matches other entries
- [x] Repository is public and MIT licensed