### PR TITLE
Add career-ops to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@
 - [AlterLab-Academic-Skills](https://github.com/AlterLab-IEU/AlterLab-Academic-Skills) - 186+ academic research skills across 13 domains for higher education and research.
 - [AlterLab_GameForge](https://github.com/AlterLab-IEU/AlterLab_GameForge) - 34 game development skills covering design, mechanics, and production pipelines.
 - [Claude Code SDK](https://github.com/SeifBenayed/claude-code-sdk) - Open-source, provider-agnostic CLI for AI agents. 13 providers, built-in tools, skill marketplace.
+- [career-ops](https://github.com/santifer/career-ops) - 14-skill collection for AI-powered job hunting: JD evaluation with A-F scoring, ATS-optimized PDF generation, portal scanners (Greenhouse/Ashby/Lever), interview prep with STAR+R stories, batch processing, and a Go dashboard TUI. Works with Claude Code, OpenCode, and Gemini CLI.
 
 
 ## 🤝 Contribution


### PR DESCRIPTION
Adding **[career-ops](https://github.com/santifer/career-ops)** (46.5K ⭐) to the 🗂️ Collections section.

### What it is

Career-ops is a 14-skill collection that turns Claude Code (and OpenCode / Gemini CLI) into an AI-powered job search command center.

### Skill modes included

- JD evaluation with A-F scoring (6-block: role summary, CV match, level strategy, comp research, personalization, interview prep)
- ATS-optimized PDF generation per job description
- Portal scanners — Greenhouse, Ashby, Lever, Wellfound (45+ companies pre-configured)
- Interview prep with STAR+R story bank (5-10 master stories that answer behavioral questions)
- Negotiation scripts (salary, geographic discount pushback, competing offer leverage)
- Batch processing — evaluate 10+ offers in parallel via sub-agents
- Pipeline integrity (dedup, status normalization, health checks)
- Go dashboard TUI for filtering and sorting

### Fit with Collections section

Sits alongside existing entries like [OpenPaw](https://github.com/daxaur/openpaw) (38-skill bundle) and [Agent Almanac](https://github.com/pjt222/agent-almanac) (317 skills / 65 agents) — same shape: a multi-skill collection for Claude Code.

### Social proof

- 46,511 stars / 9,725 forks
- README translated to 9 languages (EN/ES/DE/FR/PT-BR/KO/JA/ZH-CN/ZH-TW)
- MIT licensed
- Built by [@santifer](https://github.com/santifer), used to evaluate 740+ job offers and land a Head of Applied AI role