### PR TITLE
Add skill: heyneuron/flowhunt-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@
 - [review-claudemd](https://github.com/ykdojo/claude-code-tips/tree/main/skills/review-claudemd) - Review recent conversations to find improvements for CLAUDE.md files.
 - [hubspot-admin-skills](https://github.com/TomGranot/hubspot-admin-skills) - Skills for auditing, cleaning, enriching, and automating HubSpot CRM. Full audit → plan → execute → maintain workflow.
 - [SkillCheck-Free](https://github.com/olgasafonova/SkillCheck-Free) - Free SKILL.md validator with 30+ checks across structure, naming, and semantics. Catches common errors before deploying Claude Code skills.
+- [flowhunt-skill](https://github.com/heyneuron/flowhunt-skill) - Automation discovery audit: walks through a 5-question workflow intake, audits connected sources (Gmail, Calendar, Slack, task trackers), and produces a markdown report of automation opportunities. Install: `npx skills add heyneuron/flowhunt-skill`
 
 ## 📰 Articles & Blog Posts
 


### PR DESCRIPTION
Adding FlowHunt Skill — automation discovery audit that walks users through a 5-question workflow intake and audits connected sources (Gmail, Calendar, Slack, task trackers) to identify automation opportunities. Produces a markdown report to `~/.flowhunt/audits/`.

**Install:** `npx skills add heyneuron/flowhunt-skill`

**Repo:** https://github.com/heyneuron/flowhunt-skill

Added to the **🔧 Utility & Automation** section as it fits the automation discovery use case.