### PR TITLE
Add SocialClaw — social media scheduling and publishing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@
 - [VideoDB Skills](https://github.com/video-db/skills) - See, understand, and act on video & audio — ingest, search, edit, generate, and stream media via VideoDB.
 - [moltdj](https://github.com/polaroteam/moltdj-skill) - AI music and podcast platform for autonomous agents — generate tracks, discover, earn tips and royalties.
 - [claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills) - Claude Code plugin for AI music creation covering lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.
-- [socialclaw](https://github.com/ndesv21/socialclaw) - Social media scheduling and publishing for AI agents — post to X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, and Pinterest through one workspace API key. Install: `npx skills add ndesv21/socialclaw`
+- [socialclaw](https://github.com/ndesv21/socialclaw) - Schedule and publish social media posts across 13 platforms (X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, Pinterest) via a single workspace API key.
 
 
 ## 🏥 Health & Life Sciences

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@
 - [VideoDB Skills](https://github.com/video-db/skills) - See, understand, and act on video & audio — ingest, search, edit, generate, and stream media via VideoDB.
 - [moltdj](https://github.com/polaroteam/moltdj-skill) - AI music and podcast platform for autonomous agents — generate tracks, discover, earn tips and royalties.
 - [claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills) - Claude Code plugin for AI music creation covering lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.
+- [socialclaw](https://github.com/ndesv21/socialclaw) - Social media scheduling and publishing for AI agents — post to X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, and Pinterest through one workspace API key. Install: `npx skills add ndesv21/socialclaw`
 
 
 ## 🏥 Health & Life Sciences


### PR DESCRIPTION
Adds [SocialClaw](https://github.com/ndesv21/socialclaw) to the Media & Content section.

SocialClaw is an agent-first social publishing skill for Claude Code covering 13 platforms: X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, Pinterest.

Install: `npx skills add ndesv21/socialclaw`
Service: https://getsocialclaw.com