### PR TITLE
feat: add skills-for-humanity to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@
 
 ## 🗂️ Collections
 
+- [skills-for-humanity](https://github.com/human-avatar/skills-for-humanity) - 171 structured reasoning methodologies packaged as Claude Code skills, covering logic, probability, decision-making, creativity, ethics, writing, strategy, and more. Based on frameworks from de Bono, Meadows, Tetlock, Sun Tzu, and others. Install: `npx @human-avatar/skills-for-humanity`
 - [@clawfu/mcp-skills](https://github.com/guia-matthieu/clawfu-skills) - 169 expert-sourced marketing skills (Dunford, Schwartz, Ogilvy, Cialdini) as MCP server with brand memory.
 - [wondelai/skills](https://github.com/wondelai/skills) - 25 agent skills for UX design, marketing/CRO, sales, product strategy, and growth based on books by Norman, Cialdini, Ries, Hormozi, and others.
 - [devmarketing-skills](https://github.com/jonathimer/devmarketing-skills) - 33 skills for developer marketing — HN strategy, technical tutorials, docs-as-marketing, Reddit engagement, developer onboarding, newsletters, and SEO for devtools.


### PR DESCRIPTION
## Summary

- Adds [skills-for-humanity](https://github.com/human-avatar/skills-for-humanity) to the **Collections** section
- 171 structured reasoning methodologies packaged as Claude Code skills, covering logic, probability, decision-making, creativity, ethics, writing, strategy, and more
- Based on frameworks from de Bono, Meadows, Tetlock, Sun Tzu, and 15+ other thinkers
- Installable via `npx @human-avatar/skills-for-humanity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)