### PR TITLE
Add II-Commons Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@
 
 ## 🔬 Scientific & Research Tools
 - [claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills) - 125+ scientific skills for bioinformatics, cheminformatics, clinical research, and machine learning.
+- [ii-commons](https://github.com/Intelligent-Internet/II-Commons-Skills) - Fast, daily-updated skill and CLI for deterministic retrieval across arXiv, PubMed/PMC, and supported US policy corpora.
 - [materials-simulation-skills](https://github.com/HeshamFS/materials-simulation-skills) - Agent skills for computational materials science: numerical stability, time-stepping, linear solvers, mesh generation, simulation validation, parameter optimization, and post-processing.
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews.
 - [manus](https://github.com/sanjay3290/ai-skills/tree/main/skills/manus) - Delegate complex tasks to Manus AI agent for deep research, market analysis, product comparisons, stock analysis, and comprehensive report generation with parallel processing.


### PR DESCRIPTION
Adds II-Commons Skills to Scientific & Research Tools.\n\nII-Commons is an open-source agent skill and npm CLI for deterministic, daily-updated retrieval across arXiv, PubMed/PMC, and supported US policy corpora. It is public, auditable, and Apache-2.0 licensed.\n\nProject: https://github.com/Intelligent-Internet/II-Commons-Skills