### PR TITLE
Add alpha-insights skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 
 
 ## 📊 Data & Analysis
+- [alpha-insights](https://github.com/Ericyoung-183/alpha-insights) - Harness-enforced AI business research skill for Claude Code and Codex Desktop: consulting frameworks, evidence confidence grading, stage gates, and HTML reports.
 - [csv-data-summarizer-claude-skill](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSVs: columns, distributions, missing data, correlations.
 - [notebooklm](https://github.com/sanjay3290/ai-skills/tree/main/skills/notebooklm) - Query and manage Google NotebookLM notebooks with persistent auth, batch/multi queries, source sync, and structured exports.
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security.


### PR DESCRIPTION
Adds Alpha Insights, an open-source business research Agent Skill for Claude Code and Codex Desktop.

It focuses on structured business analysis rather than generic summarization:
- consulting-style frameworks for competitive analysis, market entry, due diligence, and strategy work
- evidence confidence grading and stage-gate validation
- professional HTML report output

Repo: https://github.com/Ericyoung-183/alpha-insights
