### PR TITLE
Add agency-agents-fork to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@
 - [AlterLab-Academic-Skills](https://github.com/AlterLab-IEU/AlterLab-Academic-Skills) - 186+ academic research skills across 13 domains for higher education and research.
 - [AlterLab_GameForge](https://github.com/AlterLab-IEU/AlterLab_GameForge) - 34 game development skills covering design, mechanics, and production pipelines.
 - [Claude Code SDK](https://github.com/SeifBenayed/claude-code-sdk) - Open-source, provider-agnostic CLI for AI agents. 13 providers, built-in tools, skill marketplace.
+- [agency-agents-fork](https://github.com/daehounan/agency-agents-fork) - 163 specialist agent personas + 24 routing skills bundled as a Claude Code plugin across 15 domains (engineering, design, finance, game-dev, marketing, paid-media, sales). Ships Korean / Japanese Business Navigators, game-dev routing across Unity / Unreal / Godot / Roblox / Blender, XR / spatial routing, and `skill-routing-arbitrator` for disambiguating ~500 ecosystem skills. One-liner install via `claude --plugin-url <release-zip>`.
 
 
 ## 🤝 Contribution


### PR DESCRIPTION
Adds `daehounan/agency-agents-fork` to the `🗂️ Collections` section.

## What this is

A Claude Code plugin bundle: 163 specialist agent personas + 24 routing skills + 16 NEXUS strategy playbooks. Fork of [msitarzewski/agency-agents](https://github.com/msitarzewski/agency-agents) with China-market agents excluded (22 files dropped) and Korean + Japanese Business Navigators added.

## Why "Collections"

Fits the same shelf as the existing `Agent Almanac`, `wondelai/skills`, `AlterLab-*` entries — multi-domain skill/agent bundles installable as a unit. Single 1-line addition at the bottom of the section to match the chronological pattern.

## Highlights

- 163 agents across 15 divisions (academic, design, engineering, finance, game-development, marketing, paid-media, product, project-management, sales, spatial-computing, specialized, strategy, support, testing)
- 24 routing skills including `korean-business`, `japanese-business`, `game-development-routing` (Unity / Unreal / Godot / Roblox / Blender), `xr-spatial-routing`, `paid-media-routing`, and `skill-routing-arbitrator` (disambiguates across ~500 wider ecosystem skills)
- `agency-roster` skill lists the full installed agent inventory on demand
- Three CI workflows green on every push (Lint Skills, audit-agent-refs, Build Plugin)
- Cross-reference audit enforced — 0 orphans across 180 backticked refs
- No outbound network calls (verified — see SECURITY.md)
- Does NOT require `--dangerously-skip-permissions`
- One-liner install — `claude --plugin-url https://github.com/daehounan/agency-agents-fork/releases/download/v1.2.0/agency-agents-fork-v1.2.0-full.zip`
- Or scoped subsets: `-engineering-finance`, `-marketing-paid-media-sales`, `-game-development`
- MIT license

Pending review at travisvn/awesome-claude-skills (PR #746, OPEN since 2026-05-18) and ComposioHQ/awesome-claude-skills (PR #894, `ready-to-merge` label applied 2026-05-22).
