### PR TITLE
Add awesome-matematic-skills-pl (Polish legal AI hub) to Document Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 - [pptx](https://github.com/anthropics/skills/tree/main/skills/pptx) - Read, generate, and adjust slides, layouts, templates.  
 - [xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
 - [revealjs-skill](https://github.com/ryanbbrown/revealjs-skill/tree/main) - Generate polished, professional presentations using the Reveal.js HTML presentation framework.
+- [awesome-matematic-skills-pl](https://github.com/matematicsolutions/awesome-matematic-skills-pl) - 22-skill collection for Polish legal practice (with EU law via SPARQL): LLM output validation pipeline (router, citation grounding, adversarial review, fidelity check), offline PII anonymization with PESEL/NIP/REGON/KRS checksum validation, SAOS case law search, EUR-Lex SPARQL, native Word Track Changes for .docx, and AI Act record-keeping bundles. Local-only for GDPR compliance. Apache-2.0 / MIT per skill.
 
 
 


### PR DESCRIPTION
Adds **awesome-matematic-skills-pl** — a 22-skill curated hub for Polish-jurisdiction legal AI — to the Document Skills section, alongside docx/pdf/pptx/xlsx and other document-centric skills.

**What the hub covers:**
- LLM output validation pipeline (router, intake check, citation grounding, adversarial review, fidelity check, audit bundle)
- Polish PII anonymization (offline, checksum-validated PESEL/NIP/REGON/KRS/IBAN/national ID)
- Case law connectors (SAOS REST API for Polish courts, EUR-Lex SPARQL for EU acts)
- Native Word Track Changes for .docx, document conversion
- GDPR (RODO) art. 32 backup mapping, AI Act art. 12 record-keeping bundles

**Validation:** v0.6.0 LIVE on 2026-05-27. Real-API smoke-tested: SAOS (`I CSK 100/22`, `III CZP 1/24`), EUR-Lex (`32024R1689` AI Act, `32016R0679` GDPR). Adopts [google/skills](https://github.com/google/skills) Safety Tiers R/M/D pattern.

**License:** Apache-2.0 / MIT per skill, curatorial MIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)