### PR TITLE
Add claude-security-engineer to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@
 - [ffuf_claude_skill](https://github.com/jthack/ffuf_claude_skill) - Integrate Claude with FFUF (fuzzing) and analyze results for vulnerabilities.
 - [owasp-security](https://github.com/agamm/claude-code-owasp) - OWASP Top 10:2025, ASVS 5.0, and Agentic AI security (2026) with code review checklists, secure patterns, and language-specific quirks for 20+ languages.
 - [systematic-debugging](https://github.com/obra/superpowers/blob/main/skills/systematic-debugging) - Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes
+- [claude-security-engineer](https://github.com/swapniltamse/claude-security-engineer) - Ten OWASP Top 10 skills for Claude Code, one per category. Invoked before the agent writes security-relevant code, not after.
 - [Trail of Bits Security Skills](https://github.com/trailofbits/skills) - Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and fix verification.
 - [varlock-claude-skill](https://github.com/wrsmith108/varlock-claude-skill) - Secure environment variable management ensuring secrets never appear in Claude sessions, terminals, logs, or git commits.
 - [sanitize](https://github.com/openclaw/skills/tree/main/skills/agentward-ai/sanitize) - Detect and redact PII from text files — 15 categories (SSNs, credit cards, API keys, etc.), zero dependencies, all processing local.


### PR DESCRIPTION
Adds [claude-security-engineer](https://github.com/swapniltamse/claude-security-engineer) to the Security & Web Testing section.

Ten OWASP Top 10 skills for Claude Code, one per category (A01-A10), plus an `owasp-security-gate` that runs all 10 in sequence. Each skill is invoked before the agent writes security-relevant code, not as a post-hoc audit. Apache 2.0.