### PR TITLE
Add md2wechat

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@
 ## ✍️ Writing & Research
 - [article-extractor](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/article-extractor) - Extract full article text and metadata from web pages.
 - [content-research-writer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/content-research-writer) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, iterating on outlines, and providing real-time feedback on each section
+- [md2wechat](https://github.com/geekjourneyx/md2wechat-skill) - Agent-native CLI and skill for turning Markdown into WeChat Official Account HTML, previewing locally, handling images/covers, and creating WeChat drafts from Claude Code, Codex, OpenCode, or OpenClaw.
 - [internal-comms](https://github.com/anthropics/skills/tree/main/skills/internal-comms) - Create internal communications (status reports, leadership updates, 3P updates, company newsletters, FAQs, incident reports, project updates, etc)
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.


### PR DESCRIPTION
## Summary

Adds `md2wechat` to the Writing & Research section.

## Why

`md2wechat` is an agent-native CLI and Claude/Codex-friendly skill for publishing Markdown articles to WeChat Official Accounts. It gives agents a concrete workflow for local preview, WeChat-compatible formatting, image/cover handling, and draft creation.

## Notes

- Repository: https://github.com/geekjourneyx/md2wechat-skill
- Best fit: Writing & Research / content publishing
- Change type: README listing only
