### PR TITLE
Add docs-to-book to Learning & Knowledge

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@
 ## 📘 Learning & Knowledge  
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.  
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
+- [docs-to-book](https://github.com/EliaTolin/docs-to-book-skills) - Turn online technical documentation into a colorful, readable PDF book, translated into the language of your choice.
 
 
 


### PR DESCRIPTION
Adds **docs-to-book** under *📘 Learning & Knowledge*.

[docs-to-book](https://github.com/EliaTolin/docs-to-book-skills) is a Claude Code skill that crawls an online technical documentation site and turns it into a colorful, readable PDF book, translated into the language of your choice. Useful for studying docs offline or producing a printable manual/ebook from a documentation website.

The skill ships a full `SKILL.md` plus scripts (crawl, extract, brand-color extraction, Typst compile), reference guides, and Typst assets. MIT licensed.