### PR TITLE
Add youtube-full

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@
 - [coinpaprika-api](https://github.com/coinpaprika/skills/tree/main/coinpaprika-api) - Crypto market data for 12K+ coins, 350+ exchanges, tickers, OHLCV, historical prices. Free, no API key.
 - [dexpaprika-api](https://github.com/coinpaprika/skills/tree/main/dexpaprika-api) - Free DEX data across 34 chains: 30M+ pools, 27M+ tokens, real-time SSE streaming, OHLCV. No API key, no rate limits.
 - [gh-star-history](https://github.com/ykdojo/gh-star-history) - Visualize and compare GitHub star history as interactive charts, with regional breakdown of stargazers.
+- **[youtube-full](https://github.com/ZeroPointRepo/youtube-skills)** - YouTube transcripts, search, channel data, and playlists via TranscriptAPI. 100 free credits.
 
 
 ## 🔬 Scientific & Research Tools


### PR DESCRIPTION
## Summary

Adds [**youtube-full**](https://github.com/ZeroPointRepo/youtube-skills) to the Data & Research section.

YouTube transcripts (with timestamps), video search, channel browsing, in-channel search, playlists, and new-upload monitoring via TranscriptAPI. 500K+ transcripts daily, fast. No yt-dlp, no headless browser, no Google API key needed.

GitHub: https://github.com/ZeroPointRepo/youtube-skills  
Install: `npx skills add ZeroPointRepo/youtube-skills --skill youtube-full`

100 free credits on install. 223 stars · 686 installs via the `skills` CLI (skills.sh/zeropointrepo/youtube-skills).