### PR TITLE
Add Forward Deployed Selling — Claude skill for enterprise AI sales

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@
 - [review-claudemd](https://github.com/ykdojo/claude-code-tips/tree/main/skills/review-claudemd) - Review recent conversations to find improvements for CLAUDE.md files.
 - [hubspot-admin-skills](https://github.com/TomGranot/hubspot-admin-skills) - Skills for auditing, cleaning, enriching, and automating HubSpot CRM. Full audit → plan → execute → maintain workflow.
 - [SkillCheck-Free](https://github.com/olgasafonova/SkillCheck-Free) - Free SKILL.md validator with 30+ checks across structure, naming, and semantics. Catches common errors before deploying Claude Code skills.
+- [forward-deployed-selling](https://github.com/vonarmen-wq/forward-deployed-selling) - Claude skill for enterprise AI sales: ICP qualification, GTM strategy, stage diagnosis, and deal thesis generation. Free and open-source.
 
 ## 📰 Articles & Blog Posts
 


### PR DESCRIPTION
## What

Adds [Forward Deployed Selling](https://github.com/vonarmen-wq/forward-deployed-selling) to the **Utility & Automation** section.

## About the Skill

**Forward Deployed Selling** is a free, open-source Claude skill built for enterprise AI sales workflows. It provides:

- **ICP Qualification** — AI-driven scoring of Ideal Customer Profile fit
- **GTM Strategy** — Adaptive go-to-market strategy for complex enterprise deals  
- **Stage Diagnosis** — Deal stage and health diagnostics
- **Deal Thesis Generation** — Structured deal narratives for internal alignment

Built by [Angel Armendariz](https://forwarddeployedselling.com), Principal at AWS and enterprise AI strategist.

## Why It Belongs Here

Enterprise AI sales is an underserved domain in the Claude skills ecosystem. This skill fills a gap alongside the existing HubSpot admin and LinkedIn automation skills — extending utility into actual deal-making and sales strategy workflows. Follows the standard Claude Skills format (SKILL.md + YAML frontmatter).