### PR TITLE
Add Codex Small Business Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@
 
 - [@clawfu/mcp-skills](https://github.com/guia-matthieu/clawfu-skills) - 169 expert-sourced marketing skills (Dunford, Schwartz, Ogilvy, Cialdini) as MCP server with brand memory.
 - [wondelai/skills](https://github.com/wondelai/skills) - 25 agent skills for UX design, marketing/CRO, sales, product strategy, and growth based on books by Norman, Cialdini, Ries, Hormozi, and others.
+- [codex-small-business-skills](https://github.com/simongonzalezdc/codex-small-business-skills) - 31 Apache-2.0 Codex skills for cash flow, invoices, CRM, support, marketing, hiring, and weekly business workflows.
 - [devmarketing-skills](https://github.com/jonathimer/devmarketing-skills) - 33 skills for developer marketing — HN strategy, technical tutorials, docs-as-marketing, Reddit engagement, developer onboarding, newsletters, and SEO for devtools.
 - [find-skills](https://github.com/agentbay-ai/agentbay-skills) - Helps users discover, search and install agent skills from the marketplace.
 - [OpenPaw](https://github.com/daxaur/openpaw) - 38-skill bundle that turns Claude Code into a personal assistant. Includes git, Telegram, Discord, Obsidian, daily briefing, and more. Run via `npx pawmode`.


### PR DESCRIPTION
## Summary
- Adds Codex Small Business Skills to the Collections section.
- The project is an Apache-2.0 Codex port of Anthropic's public Small Business skills.
- It packages 31 workflows for cash flow, invoices, CRM, support, marketing, hiring, and weekly business operations.

## Checks
- Public repository link works.
- License and upstream attribution are documented in the linked repo.
- The collection is business-workflow oriented rather than security-sensitive code.