### PR TITLE
Add staff-engineer-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@
 - [Emblem AI Agent Wallet](https://github.com/EmblemCompany/Agent-skills/tree/main/skills/emblem-ai-agent-wallet) - Multi-chain crypto wallet management across 7 blockchains (Solana, Ethereum, Base, BSC, Polygon, Hedera, Bitcoin), swaps and transfers.
 - [unity-agent-skills](https://github.com/jahro-console/unity-agent-skills) - Agent skills set for AI-assisted Unity debugging — structured logging, runtime commands, variable watching, and more.
 - [spartan-ai-toolkit](https://github.com/spartan-stratos/spartan-ai-toolkit) - Engineering workflow commands with quality gates, TDD enforcement, and atomic commits for AI coding agents.
+- [staff-engineer-mode](https://github.com/sirmarkz/staff-engineer-mode) - Major-outage lessons routed across architecture, reliability, security, delivery, and operations.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
Adds Staff Engineer Mode under Development & Code Tools.

Staff Engineer Mode packages major-outage lessons as one router skill. It routes architecture, reliability, security, delivery, and operations prompts to 54 specialist references, and it supports Claude Code, Codex, Cursor, OpenCode, Copilot, and Gemini through the upstream repo.

Validation:
- Checked for an existing Staff Engineer Mode entry
- git diff --check