### PR TITLE
Add tracedocs under Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [swarmclaw](https://github.com/swarmclawai/swarmclaw/blob/main/skills/swarmclaw.md) - Drive a self-hosted multi-agent runtime for delegating work across coding CLIs.
 - [upload-post](https://github.com/Upload-Post/upload-post-skill) - Publish and schedule media across 10+ social platforms from a single agent workflow.
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
+- [tracedocs](https://github.com/wxggzz/tracedocs) - Evidence-grounded project docs that cite their sources, plus an AI-ready index.json; never invents deployment steps.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
Adds **[tracedocs](https://github.com/wxggzz/tracedocs)** under *Development & Code Tools*.

tracedocs is a Claude Code skill that turns any codebase into an evidence-grounded Markdown documentation package plus a machine-readable `index.json`. Every operational/deployment claim cites its source file and carries a confidence label; it never invents deployment steps and records gaps instead. MIT, with a validated sample at `examples/study-docs/`.