### PR TITLE
Add orch to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [swarmclaw](https://github.com/swarmclawai/swarmclaw/blob/main/skills/swarmclaw.md) - Drive a self-hosted multi-agent runtime for delegating work across coding CLIs.
 - [upload-post](https://github.com/Upload-Post/upload-post-skill) - Publish and schedule media across 10+ social platforms from a single agent workflow.
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
+- [orch](https://github.com/daman8271/the-perfect-orchestrator) - Turn one Claude Code session into a fleet lead: spawn, brief, monitor and adversarially verify N autonomous worker sessions in tmux. Pure bash, zero daemons.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
Adds the `orch` skill to Development & Code Tools.

[the-perfect-orchestrator](https://github.com/daman8271/the-perfect-orchestrator) ships `/orch` as a Claude Code skill (also installable as a plugin): one lead session spawns, briefs, monitors and adversarially verifies N autonomous worker sessions in tmux panes. Pure bash + tmux, zero daemons. MIT.

Full disclosure: project is new (v0.2.0, days old) and I'm the author. Recorded real fleet run with raw transcripts: [docs/realrun-2026-06-06](https://github.com/daman8271/the-perfect-orchestrator/tree/main/docs/realrun-2026-06-06).