### PR TITLE
Add keelson — tracker-agnostic issue-driven agentic workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@
 - [Product-Manager-Skills](https://github.com/deanpeters/Product-Manager-Skills) - Product management skill library covering discovery, prioritization, PRDs, roadmap planning, and SaaS metrics.
 - [product-manager-skills](https://github.com/Digidai/product-manager-skills) - Senior PM agent with 6 knowledge domains, 12 templates, and 30+ frameworks covering discovery, strategy, delivery, SaaS metrics, PM career coaching (IC to CPO), and AI product craft.
 - [cup](https://github.com/krodak/clickup-cli) - ClickUp CLI for AI agents and humans. 40+ commands for tasks, sprints, time tracking. Ships as a Claude Code plugin.
+- [keelson](https://github.com/innovestrum/keelson) - Issue-driven agentic operating model for any repo and tracker (GitHub/GitLab/Jira/Linear); interviews you and writes a tracker-agnostic AGENTS.md plus a lifecycle skill-pack, letting agents run mechanical work while escalating strategic decisions to a human.
 
 
 ## 🛡 Security & Web Testing


### PR DESCRIPTION
Adds **[keelson](https://github.com/innovestrum/keelson)** (MIT) under **🤝 Collaboration & Project Management**.

keelson establishes a disciplined, issue-driven agentic operating model in any repo against any tracker (GitHub, GitLab, Jira, Linear, or any API/CLI/MCP). It ships two Agent Skills:

- **adopt-keelson** — interviews you and writes a tracker-agnostic `AGENTS.md` plus a selectable lifecycle skill-pack.
- **tune-gates** — establishes or refines just the quality gates, standalone.

The core idea: agents run mechanical work autonomously (claim issue → branch → code+doc+test → open change → move status) but escalate the moment a move touches the original design, plan, or strategy — so spec-drift surfaces immediately instead of three steps later.

Single-line addition to the existing category; link verified.