### PR TITLE
Add clone-team (Development & Code Tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [swarmclaw](https://github.com/swarmclawai/swarmclaw/blob/main/skills/swarmclaw.md) - Drive a self-hosted multi-agent runtime for delegating work across coding CLIs.
 - [upload-post](https://github.com/Upload-Post/upload-post-skill) - Publish and schedule media across 10+ social platforms from a single agent workflow.
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
+- [clone-team](https://github.com/Varalix-Digitech-Solutions/clone-team) - Multi-agent team that clones any website into a pixel-perfect UI in your chosen stack, plus a reverse-engineered ARCHITECTURE.md. Deterministic build/test loop with an unskippable Tester gate.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
Adds **clone-team** — an open-source (MIT) Claude Code skill that orchestrates a team of agents (Manager, Frontend Developer, Backend Architect, Tester) to clone any website into a pixel-perfect UI in the stack you choose, **and** produce a reverse-engineered `ARCHITECTURE.md`.

The build/test loop is a deterministic Workflow with an **unskippable Tester gate** — a page isn't done until a full visual + behavioral regression passes — and it sizes its agent fan-out to the host's RAM, plus is pausable/resumable across sessions.

Repo: https://github.com/Varalix-Digitech-Solutions/clone-team · Demo/case study: https://clone-team.varalix.com

Added under **🛠 Development & Code Tools**, matching the existing one-line format. Happy to tweak the description or placement.