### PR TITLE
feat: add TWZRD Agent Intel to Security & Web Testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@
 
 
 
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring MCP for AI agents on Solana. Verify agent wallet identity before autonomous on-chain transactions. Tools: score_agent, preflight_check (free), get_trust_receipt (x402 USDC micropayment). Config: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
+
 ## 🔧 Utility & Automation  
 - [file-organizer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/file-organizer) - Intelligently organizes your files and folders across your computer.
 - [invoice-organizer](https://github.com/ComposioHQ/awesome-claude-skills/blob/master/invoice-organizer/SKILL.md) - Automatically organizes invoices and receipts for tax preparation


### PR DESCRIPTION
Adds TWZRD Agent Intel (https://intel.twzrd.xyz) to Security and Web Testing. Trust scoring MCP for AI agents on Solana — verify wallet identity before autonomous on-chain transactions. Free: score_agent, preflight_check. Paid (x402 USDC): get_trust_receipt.