### PR TITLE
Add ltx2-vidgen-skill (self-hosted LTX-2.3 video) to Media & Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@
 - [find-scene](https://github.com/uriva/find-scene-skill) - Search and download movie/TV show scenes by dialog, time, or visual description using the FindScene API.
 - [deapi-ai/claude-code-skills](https://github.com/deapi-ai/claude-code-skills) - AI media toolkit: generate images (Flux), text-to-speech, transcribe YouTube/audio, OCR, video generation, upscale, and remove backgrounds via deAPI. Works with Cursor, Windsurf & Continue.dev.
 - [Claude Code Video Toolkit](https://github.com/digitalsamba/claude-code-video-toolkit) — AI-native video production workspace for Claude Code with Remotion, ElevenLabs, FFmpeg, and Playwright skills.
+- [ltx2-vidgen-skill](https://github.com/patraxo/ltx2-vidgen-skill) - Self-hosted LTX-2.3 (22B) AI video in Claude Code: deploys your own Modal serverless-GPU backend, then text/image/keyframe/video-to-video + canny/depth/pose control with synced audio. A few cents a clip, no per-clip meter.
 - [VideoDB Skills](https://github.com/video-db/skills) - See, understand, and act on video & audio — ingest, search, edit, generate, and stream media via VideoDB.
 - [moltdj](https://github.com/polaroteam/moltdj-skill) - AI music and podcast platform for autonomous agents — generate tracks, discover, earn tips and royalties.
 - [claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills) - Claude Code plugin for AI music creation covering lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.


### PR DESCRIPTION
Adds **[ltx2-vidgen-skill](https://github.com/patraxo/ltx2-vidgen-skill)** to 🎬 Media & Content.

A Claude Code skill that deploys your own LTX-2.3 (22B) video backend to your Modal serverless GPU, then generates from a photo or prompt — text/image/keyframe/video-to-video + IC-LoRA canny/depth/pose control, with synced audio. You own the GPU; a few cents a clip, no per-clip meter.

Public, MIT, v1.0.0, CI-validated plugin manifest. Install: `npx skills add patraxo/ltx2-vidgen-skill` or `/plugin marketplace add patraxo/ltx2-vidgen-skill`. Single-line external-link entry matching the section format (e.g. Claude Code Video Toolkit, deAPI, VideoDB).