### PR TITLE
Add teaching-skills (university teaching lifecycle suite) to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@
 - [skills-for-humanity](https://github.com/human-avatar/skills-for-humanity) - Structured reasoning methodology skills for logic, decisions, creativity, ethics, writing, and strategy.
 - [superseo-skills](https://github.com/inhouseseo/superseo-skills) - SEO skill collection for audits, briefs, article writing, E-E-A-T, topic clusters, and link building.
 - [toprank](https://github.com/nowork-studio/toprank) - SEO and Google Ads skills for audits, metadata, schema, bids, and CMS fixes.
+- [teaching-skills](https://github.com/YujxZJCN/teaching-skills) - 14-skill teaching lifecycle suite for university professors — course design, lesson building, blueprint-first assessment, submission auditing, student mentoring, evaluation analysis, slide-deck rendering, executable labs, and accreditation mapping. English + 简体中文.
 
 
 ## 🤝 Contribution


### PR DESCRIPTION
Adds [teaching-skills](https://github.com/YujxZJCN/teaching-skills) to the Collections section.

A teaching-lifecycle suite for university professors built for Claude Code: 14 skills / 78 modes covering course design (backward design + constructive alignment gates), lesson building, blueprint-first assessment with AI-era integrity audits, spec-driven submission auditing, student mentoring, evaluation analysis, plus extensions for slide-deck rendering (Marp/Pandoc/Beamer), executable labs with autograders, TA coordination, and accreditation mapping. Human checkpoints at every consequential decision; bilingual (English + 简体中文) with a zh-CN README.

Includes a [worked showcase](https://github.com/YujxZJCN/teaching-skills/tree/main/examples/showcase) (complete artifact set for a demonstration course) so reviewers can judge output quality directly. MIT licensed. Architecture inspired by academic-research-skills (credited in README; no content copied).