### PR TITLE
Add game-build-team (Development & Code Tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [swarmclaw](https://github.com/swarmclawai/swarmclaw/blob/main/skills/swarmclaw.md) - Drive a self-hosted multi-agent runtime for delegating work across coding CLIs.
 - [upload-post](https://github.com/Upload-Post/upload-post-skill) - Publish and schedule media across 10+ social platforms from a single agent workflow.
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
+- [game-build-team](https://github.com/Varalix-Digitech-Solutions/game-build-team-skill) - Multi-agent team that builds Godot 4 / GDScript game features behind two unskippable gates — a headless test gate and an "is it fun" creative gate — then verifies on-device. Deterministic build/test loop; pausable/resumable.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
Adds **game-build-team** — a Claude Code skill that builds Godot 4 / GDScript game features with a team of AI agents behind two unskippable gates: a headless test gate and an "is it fun" creative gate, then an on-device verification pass. Deterministic build/test loop; pausable/resumable across sessions and usage-limit cutoffs.

- Repo: https://github.com/Varalix-Digitech-Solutions/game-build-team-skill
- Site: https://game-build-team.varalix.com/
- MIT, installs as a Claude Code plugin.

One line, matches the list's format.