### PR TITLE
Add Ariadne Loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@
 - [blueprint](https://github.com/imbue-ai/blueprint) - Planning copilot for coding agents. Explores the codebase, asks clarifying questions, then generates a markdown plan any agent can execute in one shot.
 - [agent-lsp](https://github.com/blackwell-systems/agent-lsp) - Semantic code intelligence skills for refactor, rename, impact analysis, and verification.
 - [agenttrace-session-audit](https://github.com/luoyuctl/agenttrace/tree/master/skills/agenttrace-session-audit) - Audit AI coding sessions for cost, failures, latency, diffs, and CI gates.
+- [Ariadne Loop](https://github.com/zhangzeyu99-web/ariadne-loop/tree/main/skills/ariadne-loop) - Write verifiable loop specs, handoff packets, verifier gates, and JSON reports for Claude Code, Codex, and OpenClaw.
 - [aws-architecture-diagram-skill](https://github.com/vidanov/aws-architecture-diagram-skill) - Generate editable AWS architecture diagrams with verified icons and export formats.
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) - Specification-driven development skill that turns requirements into blueprints, build plans, and validated implementations.
 - [harness-evolver](https://github.com/raphaelchristi/harness-evolver) - Evolve agent prompts, routing, tools, and architecture with LangSmith-backed regression guards.


### PR DESCRIPTION
Adds Ariadne Loop to Development & Code Tools.

Ariadne Loop is a skill for writing verifiable loop specs, handoff packets, verifier gates, and JSON reports for Claude Code, Codex, OpenClaw, and other coding agents.

Validation: git diff --check