### PR TITLE
Add castep-dft to Scientific & Research Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@
 - [manus](https://github.com/sanjay3290/ai-skills/tree/main/skills/manus) - Delegate complex tasks to Manus AI agent for deep research, market analysis, product comparisons, stock analysis, and comprehensive report generation with parallel processing.
 - [paper-search](https://github.com/ykdojo/paper-search) - Search academic papers via OpenAlex (250M+ works, free, no API key needed). Find papers by keyword, look up details by DOI, with sorting and pagination.
 - [Junshi](https://github.com/junshi-research/research-junshi) - Personalized research strategist for Claude Code that reads your papers, tracks relevant literature, and proposes ranked research ideas with suggested first experiments. 
+- [castep-dft](https://github.com/yiqingwen0828-dotcom/castep-dft) - Run and troubleshoot CASTEP DFT calculations: geometry optimization, convergence testing, phonons, NEB diffusion barriers, and electronic structure, with a troubleshooting guide built from real HPC mistakes.
 
 
 ## ✍️ Writing & Research


### PR DESCRIPTION
Adds **[castep-dft](https://github.com/yiqingwen0828-dotcom/castep-dft)** to the Scientific & Research Tools section.

A Claude Code skill for running and troubleshooting **CASTEP** DFT calculations (computational materials science): geometry optimization, convergence testing, phonons, NEB diffusion barriers, and electronic structure. Includes working templates, an energy-parsing script, and a troubleshooting guide built from real HPC mistakes (e.g. the default centre-of-mass constraint aborting NEB runs). MIT licensed, installable via `/plugin marketplace add yiqingwen0828-dotcom/castep-dft`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)