### PR TITLE
Add Evidentia — medical citation verification & evidence appraisal

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@
 - [manus](https://github.com/sanjay3290/ai-skills/tree/main/skills/manus) - Delegate complex tasks to Manus AI agent for deep research, market analysis, product comparisons, stock analysis, and comprehensive report generation with parallel processing.
 - [paper-search](https://github.com/ykdojo/paper-search) - Search academic papers via OpenAlex (250M+ works, free, no API key needed). Find papers by keyword, look up details by DOI, with sorting and pagination.
 - [Junshi](https://github.com/junshi-research/research-junshi) - Personalized research strategist for Claude Code that reads your papers, tracks relevant literature, and proposes ranked research ideas with suggested first experiments. 
+- [Evidentia](https://github.com/kgraph57/evidentia) - Catch AI-fabricated medical citations before you publish. Verifies DOIs/PMIDs against CrossRef/PubMed/OpenAlex (4-tier classification) plus a 15-criteria evidence-appraisal skill. CLI + MCP + Claude Code plugin. Built by a pediatrician.
 
 
 ## ✍️ Writing & Research


### PR DESCRIPTION
Adds [Evidentia](https://github.com/kgraph57/evidentia) to the Scientific & Research Tools section. It extracts DOIs/PMIDs/NCT/arXiv IDs from a document and resolves each against CrossRef, PubMed, and OpenAlex — no API key — classifying every citation in 4 tiers (Verified / Bibliographic mismatch / Hallucination / Content-review-needed), distinguishing "real paper, wrong DOI" from "paper does not exist". MIT-licensed, deterministic (no LLM inside), zero runtime deps, with 38 unit tests and a 17-case live benchmark; ships as a CLI (npx evidentia), MCP server, Claude Code plugin, and a Claude Code skill that adds a 15-criteria evidence appraisal (A–F report). It fits this section because, like paper-search, it works directly against scholarly databases for research verification. Entry appended at the end of the section, matching the existing line style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)