### PR TITLE
Add seedance-prompts-skill to Media & Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@
 - [moltdj](https://github.com/polaroteam/moltdj-skill) - AI music and podcast platform for autonomous agents — generate tracks, discover, earn tips and royalties.
 - [claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills) - Claude Code plugin for AI music creation covering lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.
 - [creative-director-skill](https://github.com/smixs/creative-director-skill) - AI creative director for ideation, scoring, recursive refinement, and storytelling frameworks.
+- [seedance-prompts-skill](https://github.com/mantoufan/seedance-prompts-skill) - Turn an idea or novel into a full short-drama screenplay, then into copy-paste-ready Seedance 2.0 video prompts and timeline storyboards via a progressive command flow. Bilingual (中文/English).
 
 
 ## 🏥 Health & Life Sciences


### PR DESCRIPTION
Adds [seedance-prompts-skill](https://github.com/mantoufan/seedance-prompts-skill) under **🎬 Media & Content**.

It's a Claude Skill (also works with ChatGPT / other LLMs) for AI video creation with ByteDance's **Seedance 2.0**: it turns an idea or a novel into a full short-drama screenplay, then converts the screenplay/article/outline into copy-paste-ready Seedance 2.0 video prompts and audio-visual timeline storyboards, driven by a progressive command flow (`/start /plan /characters /outline /episode /review /compliance /export`). Bilingual docs (中文 + English).

Fits alongside the existing video-prompting / video-toolkit entries in that section. Added one entry at the bottom of the category, matching the existing `- [name](url) - description.` format.