### PR TITLE
Add Dashmotion (animated technical diagrams skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [swarmclaw](https://github.com/swarmclawai/swarmclaw/blob/main/skills/swarmclaw.md) - Drive a self-hosted multi-agent runtime for delegating work across coding CLIs.
 - [upload-post](https://github.com/Upload-Post/upload-post-skill) - Publish and schedule media across 10+ social platforms from a single agent workflow.
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
+- [Dashmotion](https://github.com/csthink/dashmotion) - A Claude skill that turns a description or Mermaid source into a self-contained animated technical diagram: one HTML file, pure SVG/CSS, no JavaScript, with flowing connectors and request dots travelling through the system.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
Adds **Dashmotion** under Development & Code Tools.

An open-source (MIT) Claude skill that turns a plain-English description — or a Mermaid source — into a self-contained animated technical diagram: one HTML file, pure SVG/CSS, no JavaScript. Flowing connectors and request dots that travel through the system (flow + architecture modes). Installs via `npx skills add csthink/dashmotion`.

Live demo (real output, not a video): https://csthink.github.io/dashmotion/

Kept the list's existing format. Thanks for maintaining this.
