### PR TITLE
Add en-zh-translation-polish skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@
 - [ru-text](https://github.com/talkstream/ru-text) - Russian text quality: ~1,040 rules for typography, info-style, editorial, UX writing, business correspondence
 - [md2wechat](https://github.com/geekjourneyx/md2wechat-skill) - Convert Markdown into WeChat Official Account drafts with preview, image, and cover handling.
 - [buyer-eval](https://github.com/salespeak-ai/buyer-eval-skill) - Evaluate B2B vendors by interrogating agents, checking claims, and scoring weighted criteria.
+- [en-zh-translation-polish](https://github.com/HoraceLuBFA/en-zh-translation-polish) - Translate English into idiomatic, translationese-free Chinese with paragraph-by-paragraph English-Chinese bilingual output; methodology distilled from a classic translation textbook.
 
 
 ## 📘 Learning & Knowledge  


### PR DESCRIPTION
Adds **en-zh-translation-polish** to *Writing & Research*.

English→Chinese translation skill that produces idiomatic, translationese-free Chinese plus paragraph-by-paragraph English-Chinese bilingual output. Methodology distilled from a classic translation textbook into a 0–7 stage polish workflow.

- Repo: https://github.com/HoraceLuBFA/en-zh-translation-polish
- Install: `npx skills add -g HoraceLuBFA/en-zh-translation-polish`
- License: MIT