### PR TITLE
Add Outbound Pipeline skill to Utility & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@
 - [pua](https://github.com/tanweai/pua) - Corporate motivation skill that pushes AI agents to exhaust options before giving up.
 - [sequenzy-email-marketing](https://clawhub.ai/polnikale/sequenzy-email-marketing) - Operate Sequenzy email marketing workflows for subscribers, campaigns, sequences, and templates.
 - [TweetClaw](https://github.com/Xquik-dev/tweetclaw) - X/Twitter automation skill for search, posting, follower export, monitors, webhooks, and giveaways.
+- [Outbound Pipeline](https://github.com/SRKrukowski/outbound-pipeline-playbook) - One-command skill that turns an ICP into personalized, research-backed cold-email drafts in Gmail (Exa research, Apollo enrichment, Claude drafting), human-reviewed before send.
 
 ## 📰 Articles & Blog Posts
 


### PR DESCRIPTION
Adds **Outbound Pipeline** to the Utility & Automation section, alongside the existing sales/outreach skills (linkedin, hubspot-admin-skills, sequenzy-email-marketing).

An open-source Claude Code skill + install playbook that turns an ICP definition into personalized, research-backed cold-email drafts staged in Gmail for human review. One command runs Exa research, Apollo enrichment, and Claude drafting; nothing sends without a human clicking Send. MIT licensed, documented walkthrough included.

Repo: https://github.com/SRKrukowski/outbound-pipeline-playbook