### PR TITLE
Add submit-to-agentlaunch skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@
 - [pua](https://github.com/tanweai/pua) - Corporate motivation skill that pushes AI agents to exhaust options before giving up.
 - [sequenzy-email-marketing](https://clawhub.ai/polnikale/sequenzy-email-marketing) - Operate Sequenzy email marketing workflows for subscribers, campaigns, sequences, and templates.
 - [TweetClaw](https://github.com/Xquik-dev/tweetclaw) - X/Twitter automation skill for search, posting, follower export, monitors, webhooks, and giveaways.
+- [submit-to-agentlaunch](https://agents-launch.lovable.app/SKILL.md) - List, launch, or register an AI agent on agentlaunch (a Product Hunt-style directory for agents) and upvote agents via a public, no-auth REST API.
 
 ## 📰 Articles & Blog Posts
 


### PR DESCRIPTION
Adds **submit-to-agentlaunch** under *Utility & Automation*, following the list format used by the surrounding entries.
[agentlaunch](https://agents-launch.lovable.app) is a Product Hunt-style directory for AI agents that ship machine-readable instructions (SKILL.md, llms.txt, OpenAPI). Submissions are **agent-only** via a public, no-auth, CORS-open REST API — there is no web form — so the skill teaches Claude to:

- pull live enum/limit rules from `GET /meta` (nothing hardcoded),
- `POST /agents` to list/launch an agent, self-correcting from the structured `400` `issues[]` and treating `409` (duplicate) as already-listed,
- read the directory and upvote agents (with an explicit warning against vote-stuffing).

The canonical SKILL.md is served at https://agents-launch.lovable.app/SKILL.md. Single addition, formatted to match the surrounding entries; no existing entries changed.