### PR TITLE
Add novu-connect skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@
 - [pua](https://github.com/tanweai/pua) - Corporate motivation skill that pushes AI agents to exhaust options before giving up.
 - [sequenzy-email-marketing](https://clawhub.ai/polnikale/sequenzy-email-marketing) - Operate Sequenzy email marketing workflows for subscribers, campaigns, sequences, and templates.
 - [TweetClaw](https://github.com/Xquik-dev/tweetclaw) - X/Twitter automation skill for search, posting, follower export, monitors, webhooks, and giveaways.
+- [novu-connect](https://github.com/iampearceman/novu-connect-skill) - Connect a customer-facing AI agent to the messaging channels users already use (Slack, Email, Telegram, WhatsApp, MS Teams) with Novu Connect (`npx novu connect`).
 
 ## 📰 Articles & Blog Posts
 


### PR DESCRIPTION
Adding the **novu-connect** skill to Utility & Automation.

It teaches Claude to connect a customer-facing AI agent to the messaging channels users already use (Slack, Email, Telegram, WhatsApp, MS Teams) with Novu Connect, via `npx novu connect`. Grounded in Novu's published agent onboarding (https://novu.co/agents.md).

Skill repo: https://github.com/iampearceman/novu-connect-skill