### PR TITLE
Add Forward Deployed Selling — Claude skill for enterprise AI sales

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@
 - [moodtrip-hotel-search](https://github.com/adiny/moodtrip-hotel-search) - Hotel search, comparison, reviews, pricing, and booking handoff via MoodTrip.ai MCP server. 12 tools including semantic search, room matching, and price intelligence.
 - [review-claudemd](https://github.com/ykdojo/claude-code-tips/tree/main/skills/review-claudemd) - Review recent conversations to find improvements for CLAUDE.md files.
 - [hubspot-admin-skills](https://github.com/TomGranot/hubspot-admin-skills) - Skills for auditing, cleaning, enriching, and automating HubSpot CRM. Full audit → plan → execute → maintain workflow.
+- [forward-deployed-selling](https://github.com/vonarmen-wq/forward-deployed-selling) - Enterprise AI sales advisor for complex B2B deals. ICP qualification, GTM strategy, account thesis generation, deal coaching, and deal scoring. Built by an AWS enterprise AI strategist. Apache 2.0.
 - [SkillCheck-Free](https://github.com/olgasafonova/SkillCheck-Free) - Free SKILL.md validator with 30+ checks across structure, naming, and semantics. Catches common errors before deploying Claude Code skills.
 - [Imprint](https://github.com/ilang-ai/Imprint) - Portable AI collaboration profile for memory, planning, review, debugging, testing, and workflow habits.
 - [pua](https://github.com/tanweai/pua) - Corporate motivation skill that pushes AI agents to exhaust options before giving up.


### PR DESCRIPTION
## What

Adds [Forward Deployed Selling](https://github.com/vonarmen-wq/forward-deployed-selling) to the **Utility & Automation** section.

## About the Skill

**Forward Deployed Selling** is a free, open-source Claude skill built for enterprise AI sales workflows. It provides:

- **ICP Qualification** — Forces market × persona × channel alignment before any downstream work
- **GTM Strategy** — Derives motion, channel mix, and messaging anchor from the qualified ICP
- **Account Thesis Generation** — Sourced one-page POV on any target account, labeled KNOWN/INFERRED
- **Deal Coaching** — Diagnoses wait states and returns a recovery plan
- **Deal Scoring** — Stage + risk + velocity → deal tier

Built by [Angel Armendariz](https://angelarmendariz.com), Enterprise AI Strategist at AWS. ⭐ 64 stars, 11 forks.

## Why It Belongs Here

Enterprise AI sales is an underserved domain in the Claude skills ecosystem. This skill fills a gap alongside the existing HubSpot admin and LinkedIn automation skills — extending utility into actual deal-making and sales strategy workflows. Follows standard Claude Skills format (SKILL.md + YAML frontmatter). Apache 2.0.