### PR TITLE
Add consumer-dispute-assistant skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@
 
 
 ## 🔧 Utility & Automation  
+- [consumer-dispute-assistant](https://github.com/JerryNee/consumer-dispute-agent-skill/tree/main/skills/consumer-dispute-assistant) - Build refund and billing dispute case packs.
 - [file-organizer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/file-organizer) - Intelligently organizes your files and folders across your computer.
 - [invoice-organizer](https://github.com/ComposioHQ/awesome-claude-skills/blob/master/invoice-organizer/SKILL.md) - Automatically organizes invoices and receipts for tax preparation
 - [skill-creator](https://github.com/anthropics/skills/tree/main/skills/skill-creator) - Template / helper to build new Claude skills.  


### PR DESCRIPTION
Adds `consumer-dispute-assistant` under Utility & Automation.

It is a public Claude/Codex-compatible Agent Skill for building refund, subscription, and billing dispute case packs, with demo output and reusable templates.
