### PR TITLE
Add NotFair — SEO, Google Ads & Meta Ads skills with live MCP data

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@
 - [skills-for-humanity](https://github.com/human-avatar/skills-for-humanity) - Structured reasoning methodology skills for logic, decisions, creativity, ethics, writing, and strategy.
 - [superseo-skills](https://github.com/inhouseseo/superseo-skills) - SEO skill collection for audits, briefs, article writing, E-E-A-T, topic clusters, and link building.
 - [toprank](https://github.com/nowork-studio/toprank) - SEO and Google Ads skills for audits, metadata, schema, bids, and CMS fixes.
+- [NotFair](https://github.com/nowork-studio/NotFair) - Open-source Claude Code skills for [SEO](https://github.com/nowork-studio/NotFair/tree/main/seo), [Google Ads](https://github.com/nowork-studio/NotFair/tree/main/google-ads), and [Meta Ads](https://github.com/nowork-studio/NotFair/tree/main/meta-ads); connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.
 
 
 ## 🤝 Contribution


### PR DESCRIPTION
Hi, thanks for maintaining this list!

I'd like to add **[NotFair](https://github.com/nowork-studio/NotFair)**, an open-source Claude Code plugin (~2.9k stars, MIT license) that covers marketing automation through three skill areas:

- **[seo/](https://github.com/nowork-studio/NotFair/tree/main/seo)** — site analysis, keyword research, meta tags, schema markup, GEO optimization, and content writing
- **[google-ads/](https://github.com/nowork-studio/NotFair/tree/main/google-ads)** — audits, wasted-spend detection, search-term cleanup, keyword and bid management
- **[meta-ads/](https://github.com/nowork-studio/NotFair/tree/main/meta-ads)** — Meta (Facebook + Instagram) Ads: ROAS, creative fatigue, audience overlap

It connects to live data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. I've placed it in the Collections section alongside the related toprank entry (same author, older product).

Happy to reword, move, or trim the entry however works best for this list. Thanks!