### PR TITLE
Add forward-deployed-selling — enterprise AI sales methodology skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@
 - [cup](https://github.com/krodak/clickup-cli) - ClickUp CLI for AI agents and humans. 40+ commands for tasks, sprints, time tracking. Ships as a Claude Code plugin.
 
 
+- [forward-deployed-selling](https://github.com/vonarmen-wq/forward-deployed-selling) - Enterprise AI sales methodology for Claude — ICP qualification, GTM strategy, thesis generation, deal coaching, and deal scoring. Built on 20 years of closing enterprise AI deals at AWS. Apache 2.0.
+
 ## 🛡 Security & Web Testing
 - [VibeSec-Skill](https://github.com/BehiSecc/VibeSec-Skill) - VibeSec helps Claude write secure code and prevent common vulnerabilities.
 - [defense-in-depth](https://github.com/obra/superpowers/blob/main/skills/defense-in-depth) - Implement multi-layered testing and security best practices.


### PR DESCRIPTION
## What is this?

**Forward Deployed Selling** is a free, open-source Claude skill that turns Claude into an enterprise sales advisor. Built on 20 years of closing enterprise AI deals at AWS.

**GitHub:** https://github.com/vonarmen-wq/forward-deployed-selling  
**Stars:** 65 | **Apache 2.0**

## What does it do?

- ICP Qualification (hard stop — won't generate downstream work until ICP is confirmed)
- GTM Strategy derived from ICP
- Thesis Generation — sourced one-page POV on any account before the first call
- Deal Coaching — diagnoses stall states and returns recovery plans
- Deal Scoring — stage + risk + velocity → tier

## Why it belongs here

Active project, 65 GitHub stars, top post on r/claudeskills this week (87 upvotes, 46K views). Adds a sales/GTM capability gap to the list under Collaboration & Project Management.

---

Install in 30 seconds:
```
git clone https://github.com/vonarmen-wq/forward-deployed-selling ~/.claude/skills/forward-deployed-selling
```