### PR TITLE
Add 3 free skills: Socratic Code Reviewer, Systematic Bug Debugger, TDD Loop Master

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@
 - [swarmclaw](https://github.com/swarmclawai/swarmclaw/blob/main/skills/swarmclaw.md) - Drive a self-hosted multi-agent runtime for delegating work across coding CLIs.
 - [upload-post](https://github.com/Upload-Post/upload-post-skill) - Publish and schedule media across 10+ social platforms from a single agent workflow.
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
+- [Socratic Code Reviewer](https://github.com/laki-arnsteinlarsen/strategistkit-skills/tree/main/socratic-code-reviewer) - Reviews code/diffs by interrogating intent, edge cases, and trade-offs; a senior reviewer's questions, not a checklist.
+- [Systematic Bug Debugger](https://github.com/laki-arnsteinlarsen/strategistkit-skills/tree/main/systematic-bug-debugger) - Root-cause debugging from symptoms and stack traces; handles heisenbugs and "works locally, fails in prod".
+- [TDD Loop Master](https://github.com/laki-arnsteinlarsen/strategistkit-skills/tree/main/tdd-loop-master) - Drives red-green-refactor: builds a test list, writes tests first, keeps the discipline tight.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
Adds three free, MIT-licensed SKILL.md skills for code review, debugging, and TDD to Development & Code Tools.
Each is a self-contained folder with a SKILL.md, tested with Claude Code and Cursor.
Repo: https://github.com/laki-arnsteinlarsen/strategistkit-skills
Note: Socratic Code Reviewer and Systematic Bug Debugger are also security-relevant (they surface bugs, edge cases, and risky paths) — happy to move them to Security & Web Testing if you prefer.