### PR TITLE
Add multi-LLM reasoning skills (debate / reflection / recursive-meta-cognition)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,9 @@
 - [pua](https://github.com/tanweai/pua) - Corporate motivation skill that pushes AI agents to exhaust options before giving up.
 - [sequenzy-email-marketing](https://clawhub.ai/polnikale/sequenzy-email-marketing) - Operate Sequenzy email marketing workflows for subscribers, campaigns, sequences, and templates.
 - [TweetClaw](https://github.com/Xquik-dev/tweetclaw) - X/Twitter automation skill for search, posting, follower export, monitors, webhooks, and giveaways.
+- [multi-llm-debate](https://github.com/buddypia/agent-skills/tree/main/skills/multi-llm-debate) - Runs a 3-role debate (proponent / opponent / moderator) across different-vendor LLMs (Gemini, Claude, GPT) to weigh trade-offs and reach a multi-perspective verdict on hard decisions. Runs via subscription-authenticated CLIs; API keys also supported.
+- [multi-llm-reflection](https://github.com/buddypia/agent-skills/tree/main/skills/multi-llm-reflection) - Generator→Critic→Refiner loop across different-vendor LLMs (Gemini, Claude, GPT) that drafts content, critiques it, and produces an improved version through cross-model self-critique.
+- [multi-llm-recursive-meta-cognition](https://github.com/buddypia/agent-skills/tree/main/skills/multi-llm-recursive-meta-cognition) - 5-stage pipeline (decompose → solve → verify → integrate → reflect) across different-vendor LLMs (Gemini, Claude, GPT) for rigorous multi-step reasoning and deep problem-solving.
 
 ## 📰 Articles & Blog Posts
 


### PR DESCRIPTION
## What

Adds three multi-LLM reasoning skills under **🔧 Utility & Automation**:

- **[multi-llm-debate](https://github.com/buddypia/agent-skills/tree/main/skills/multi-llm-debate)** — A 3-role debate (proponent / opponent / moderator) where different-vendor LLMs (Gemini, Claude, GPT) argue a topic to reach a multi-perspective verdict. For hard decisions and trade-off analysis.
- **[multi-llm-reflection](https://github.com/buddypia/agent-skills/tree/main/skills/multi-llm-reflection)** — A Generator→Critic→Refiner loop across different-vendor LLMs that drafts content, critiques it, and produces an improved version through cross-model self-critique.
- **[multi-llm-recursive-meta-cognition](https://github.com/buddypia/agent-skills/tree/main/skills/multi-llm-recursive-meta-cognition)** — A 5-stage pipeline (decompose → solve → verify → integrate → reflect) across different-vendor LLMs for rigorous multi-step reasoning and deep problem-solving.

## Why these belong here

Most skills in the list deepen a single model's output. These instead **orchestrate different-vendor LLMs against each other** (Gemini / Claude / GPT) so blind spots from any one model are caught by another — useful for decisions, writing, and complex reasoning. Each skill ships a documented `SKILL.md`, cross-platform runners (`run.sh` / `run.ps1` / `run.cmd`), and runs under existing subscription-authenticated CLIs (API keys also supported).

## Notes for the maintainer

- All three live in one open-source repo (MIT) and the links resolve to self-contained skill folders.
- I placed them in **Utility & Automation** as the closest existing home for general-purpose, model-agnostic reasoning tools; happy to move them if you prefer another category.

## Checklist

- [x] Entry format matches the list: `- [name](url) - description`
- [x] Links verified — public repo, each resolves to a skill folder with a `SKILL.md`
- [x] Single-file change (`README.md`), three additions, no reordering of existing entries
