### PR TITLE
Add otelcol-doctor to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [swarmclaw](https://github.com/swarmclawai/swarmclaw/blob/main/skills/swarmclaw.md) - Drive a self-hosted multi-agent runtime for delegating work across coding CLIs.
 - [upload-post](https://github.com/Upload-Post/upload-post-skill) - Publish and schedule media across 10+ social platforms from a single agent workflow.
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
+- [otelcol-doctor](https://github.com/s3onghyun/otelcol-doctor) - Write, fix, and validate OpenTelemetry Collector configs (processor order, core-vs-contrib, OTTL, spanmetrics, tail-sampling), then run otelcol validate.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
Adds [otelcol-doctor](https://github.com/s3onghyun/otelcol-doctor) under **Development & Code Tools** — a vendor-neutral skill that writes, fixes, and validates **OpenTelemetry Collector** configs (processor order, core-vs-contrib components, pull-vs-push exporters, OTTL, spanmetrics dual-wiring, tail-sampling topology), finishing with `otelcol validate`. Public repo, Apache-2.0, with SKILL.md + a component catalog + validated examples.