### PR TITLE
Add ax-extract-workflow skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@
 - [blueprint](https://github.com/imbue-ai/blueprint) - Planning copilot for coding agents. Explores the codebase, asks clarifying questions, then generates a markdown plan any agent can execute in one shot.
 - [agent-lsp](https://github.com/blackwell-systems/agent-lsp) - Semantic code intelligence skills for refactor, rename, impact analysis, and verification.
 - [agenttrace-session-audit](https://github.com/luoyuctl/agenttrace/tree/master/skills/agenttrace-session-audit) - Audit AI coding sessions for cost, failures, latency, diffs, and CI gates.
+- [ax-extract-workflow](https://github.com/Necmttn/ax/tree/main/skills/ax-extract-workflow) - Reconstructs how a feature shipped from local ax session history: skill order, decisions, and subagent handoffs.
 - [aws-architecture-diagram-skill](https://github.com/vidanov/aws-architecture-diagram-skill) - Generate editable AWS architecture diagrams with verified icons and export formats.
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) - Specification-driven development skill that turns requirements into blueprints, build plans, and validated implementations.
 - [harness-evolver](https://github.com/raphaelchristi/harness-evolver) - Evolve agent prompts, routing, tools, and architecture with LangSmith-backed regression guards.


### PR DESCRIPTION
Adds ax-extract-workflow to the Development & Code Tools section.

The skill helps reconstruct how a feature shipped from local ax session history: skill order, decisions, and subagent handoffs. It fits next to the existing session audit and replay tools, but focuses on the reusable workflow behind the work rather than only the trace.

Checks:
- README-only change
- Added link returns 200
- `git diff --check` passed

---

_Generated with [ax](https://github.com/Necmttn/ax)._

