### PR TITLE
Add Skillselion to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@
 - [skills-for-humanity](https://github.com/human-avatar/skills-for-humanity) - Structured reasoning methodology skills for logic, decisions, creativity, ethics, writing, and strategy.
 - [superseo-skills](https://github.com/inhouseseo/superseo-skills) - SEO skill collection for audits, briefs, article writing, E-E-A-T, topic clusters, and link building.
 - [toprank](https://github.com/nowork-studio/toprank) - SEO and Google Ads skills for audits, metadata, schema, bids, and CMS fixes.
+- [Skillselion](https://skillselion.com) - Curated directory of Claude Code agent skills, MCP servers and plugin marketplaces, ranked by installs and GitHub stars.
 
 
 ## 🤝 Contribution


### PR DESCRIPTION
### What
Adds **[Skillselion](https://skillselion.com)** to the **🗂️ Collections** section.

### Why it fits
Skillselion is a curated directory of Claude Code agent skills, MCP servers and plugin marketplaces, ranked by installs and GitHub stars. It sits alongside the other discovery directories already listed here (e.g. `agentskill.sh`, `find-skills`) - a starting point for finding skills/MCPs worth installing.

Entry added (matches the section's format, description ends in a period):
```
- [Skillselion](https://skillselion.com) - Curated directory of Claude Code agent skills, MCP servers and plugin marketplaces, ranked by installs and GitHub stars.
```

One item, single line, no other changes. Thanks for maintaining the list!