### PR TITLE
Add Skillselion to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@
 - [skills-for-humanity](https://github.com/human-avatar/skills-for-humanity) - Structured reasoning methodology skills for logic, decisions, creativity, ethics, writing, and strategy.
 - [superseo-skills](https://github.com/inhouseseo/superseo-skills) - SEO skill collection for audits, briefs, article writing, E-E-A-T, topic clusters, and link building.
 - [toprank](https://github.com/nowork-studio/toprank) - SEO and Google Ads skills for audits, metadata, schema, bids, and CMS fixes.
+- [Skillselion](https://skillselion.com) - Curated directory of Claude Code agent skills, MCP servers and plugin marketplaces, ranked by installs and GitHub stars.
 
 
 ## 🤝 Contribution


### PR DESCRIPTION
### What
Adds **[Skillselion](https://skillselion.com)** to the **🗂️ Collections** section.

### Why it fits
Skillselion is a curated directory of Claude Code agent skills, MCP servers and plugin marketplaces, ranked by installs and GitHub stars - a starting point for finding skills and MCPs worth installing. It sits alongside the discovery directories already in Collections (e.g. `agentskill.sh`, `find-skills`).

One item, single line, matches the section format. Thanks for maintaining the list!