### PR TITLE
Add todo.txt-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@
 - [Product-Manager-Skills](https://github.com/deanpeters/Product-Manager-Skills) - Product management skill library covering discovery, prioritization, PRDs, roadmap planning, and SaaS metrics.
 - [product-manager-skills](https://github.com/Digidai/product-manager-skills) - Senior PM agent with 6 knowledge domains, 12 templates, and 30+ frameworks covering discovery, strategy, delivery, SaaS metrics, PM career coaching (IC to CPO), and AI product craft.
 - [cup](https://github.com/krodak/clickup-cli) - ClickUp CLI for AI agents and humans. 40+ commands for tasks, sprints, time tracking. Ships as a Claude Code plugin.
+- [todo.txt-skill](https://github.com/aguilera-ee/todo.txt-skill) - Manage a durable todo.txt task list by driving the official todo.sh CLI, with no app or vendor lock in.
 
 
 ## 🛡 Security & Web Testing


### PR DESCRIPTION
Adds todo.txt-skill under Collaboration & Project Management.

It manages a durable todo.txt task list by driving the official todo.sh CLI, giving an agent a plain text task list it can use across conversations.

Repository: https://github.com/aguilera-ee/todo.txt-skill