### PR TITLE
Add skill: npm-package-release-hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [swarmclaw](https://github.com/swarmclawai/swarmclaw/blob/main/skills/swarmclaw.md) - Drive a self-hosted multi-agent runtime for delegating work across coding CLIs.
 - [upload-post](https://github.com/Upload-Post/upload-post-skill) - Publish and schedule media across 10+ social platforms from a single agent workflow.
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
+- [npm-package-release-hardening](https://github.com/SSBrouhard/npm-package-release-hardening) - Harden a JS/TS npm package before public release: tarball secret-leak review, runtime-floor (@types/node) checks, CI/Dependabot/security baseline, and verified-only reporting.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
Adds **npm-package-release-hardening** under **🛠 Development & Code Tools**.

- Repo: https://github.com/SSBrouhard/npm-package-release-hardening
- What it does: takes a JS/TS npm package from "works locally" to "safe to publish" — reviews the tarball for shipped secrets/junk, enforces the `@types/node` runtime floor against `engines.node`, sets up a CI/Dependabot/security baseline, and reports only what was actually verified.
- Built on the [Agent Skills](https://agentskills.io) open standard (works in Claude Code, Codex, Cursor, etc.).
- Includes `SKILL.md`, `README.md`, and an MIT `LICENSE`.