### PR TITLE
Add vibe-creating-skill to Media & Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@
 - [moltdj](https://github.com/polaroteam/moltdj-skill) - AI music and podcast platform for autonomous agents — generate tracks, discover, earn tips and royalties.
 - [claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills) - Claude Code plugin for AI music creation covering lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.
 - [creative-director-skill](https://github.com/smixs/creative-director-skill) - AI creative director for ideation, scoring, recursive refinement, and storytelling frameworks.
+- [vibe-creating-skill](https://github.com/Alisa0808/vibe-creating-skill) - Rewrites a rough idea into a model-ready text-to-video prompt using ByteDance's "Vibe Creating" paradigm (Seedance 2.0): describe the story, let the model handle the cinematography. Works with Seedance, Sora, Kling, Veo and more. Bilingual EN/中文.
 
 
 ## 🏥 Health & Life Sciences


### PR DESCRIPTION
## What is this?

[vibe-creating-skill](https://github.com/Alisa0808/vibe-creating-skill) is an open-source, bilingual (EN/中文) Agent Skill (single `SKILL.md`, open standard) that implements ByteDance's "Vibe Creating" prompt paradigm — introduced alongside the Seedance 2.0 video model. Instead of over-specifying focal lengths, fps, and shot numbers, you describe the story/scene in plain language and let the model handle the cinematography. The skill is judgment-first: it decides whether your input even suits this style before rewriting.

## Why it fits Media & Content

This category already lists video-prompting and generation skills (e.g. `video-prompting-skill`, `imagen`, the various video toolkits). vibe-creating-skill is squarely in the same space: a prompt-engineering skill for text-to-video generation (Seedance, Sora, Kling, Veo, and more).

- Open source (MIT), public repo
- Follows the `SKILL.md` standard; runs in Claude Code, Codex, OpenClaw, Hermes
- Bilingual EN/中文 docs

Added one line to the end of the Media & Content section, matching the existing `[name](url) - description` format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)