### PR TITLE
Add Motion Graphics Skills to Media & Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@
 - [Claude Code Video Toolkit](https://github.com/digitalsamba/claude-code-video-toolkit) — AI-native video production workspace for Claude Code with Remotion, ElevenLabs, FFmpeg, and Playwright skills.
 - [VideoDB Skills](https://github.com/video-db/skills) - See, understand, and act on video & audio — ingest, search, edit, generate, and stream media via VideoDB.
 - [moltdj](https://github.com/polaroteam/moltdj-skill) - AI music and podcast platform for autonomous agents — generate tracks, discover, earn tips and royalties.
+- [Motion Graphics Skills](https://github.com/iart-ai/motion-skills) - 50 skills across 14 installable packs for motion graphics, animation & video — kinetic typography, data-viz charts, explainers, TikTok/Reels, 3D WebGL, and Manim math animation. Each ships a render→screenshot→self-check loop; video renders via Remotion/Manim.
 - [claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills) - Claude Code plugin for AI music creation covering lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.
 - [creative-director-skill](https://github.com/smixs/creative-director-skill) - AI creative director for ideation, scoring, recursive refinement, and storytelling frameworks.
 


### PR DESCRIPTION
Adds [motion-skills](https://github.com/iart-ai/motion-skills) to **Media & Content**.

- 50 open-source skills across 14 installable packs
- Covers kinetic typography, data-viz charts, explainers, TikTok/Reels, 3D WebGL, and Manim math animation
- Each skill ships a render → screenshot → self-check loop (video via Remotion/Manim, web via standalone HTML)
- Anthropic open Skill format — works with Claude Code, Cursor, Codex, and 40+ agents
- MIT licensed