### PR TITLE
Add suede-creator-skills to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [swarmclaw](https://github.com/swarmclawai/swarmclaw/blob/main/skills/swarmclaw.md) - Drive a self-hosted multi-agent runtime for delegating work across coding CLIs.
 - [upload-post](https://github.com/Upload-Post/upload-post-skill) - Publish and schedule media across 10+ social platforms from a single agent workflow.
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
+- [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - 23-skill pack for Claude Code and Codex: agent orchestration with WIP collision detection and rollback trees, a Codex CLI worker fleet, code review with an A-F ship grade, AI eval scaffolding, plus design, copy, and SEO/AEO/AI-EO audits. MIT licensed.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
## What's being added

[suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) — a 23-skill pack for Claude Code and Codex.

## What it includes

Agent orchestration with WIP collision detection and rollback trees, a Codex CLI worker fleet (Claude orchestrates parallel OpenAI Codex CLI workers), code review with an A-F ship grade across evidence-backed lanes, AI eval scaffolding, plus design, copy, and SEO/AEO/AI-EO audits. MIT licensed, runs locally.

## Note on this update

This PR previously targeted the Media & Content section with a stale skill count (21) and a music-only framing. Recategorized to Development & Code Tools and updated the description to match the pack's current, broader scope.