### PR TITLE
Add pentest-report-skill to Security & Web Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@
 - [webapp-testing](https://github.com/anthropics/skills/tree/main/skills/webapp-testing) - Toolkit for interacting with and testing local web applications using Playwright.
 - [ironclaw-agent-guard](https://github.com/wd041216-bit/ironclaw-agent-guard) - Security review skill and CLI/MCP companion for risky tool calls, prompt injection, secret redaction, and audit-friendly agent workflows.
 - [shellward-security-guide](https://github.com/jnMetaCode/shellward/tree/main/skills/security-guide) - AI agent security guide for prompt injection, DLP, dangerous command blocking, and PII scanning.
-
+- [pentest-report-skill](https://github.com/KonstiJo/pentest-report-skill) - Compile pentest findings into audit-ready reports (DE/EN) with automated compliance checks against BSI, OWASP (WSTG/ASVS), PTES, NIST 800-115, PCI-DSS v4, DiGA/BfArM, and OSCP; ingests nmap/Burp/Nuclei/Nessus/BloodHound/Trivy output and renders Markdown, PDF, and SysReptor JSON.
 
 
 ## 🔧 Utility & Automation  


### PR DESCRIPTION
Adds `pentest-report-skill` to the Security & Web Testing section.

A standards-compliance layer for pentest reports: it takes findings or raw scanner output (nmap, Burp, Nuclei, Nessus, BloodHound, Trivy) and produces an audit-ready report in German or English, validated against a chosen standard (BSI Praxisleitfaden / Durchfuehrungskonzept, OWASP WSTG/ASVS, PTES, NIST 800-115, PCI-DSS v4, DiGA/BfArM, OSCP). Renders Markdown, PDF, and SysReptor import JSON. Also installable as a Claude Code plugin via a marketplace.json. MIT-licensed.

Repo: https://github.com/KonstiJo/pentest-report-skill