### PR TITLE
Add a few Claude Code engineering skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@
 
 
 ## 🎬 Media & Content
+- [claude-code-mix-compare](https://github.com/gyujeongion/claude-code-mix-compare) - git diff for audio mixes: time-align two versions and phase-invert to show what actually changed, per stem and per band.
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [video-downloader](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/video-downloader) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival.
 - [image-enhancer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/image-enhancer) - Improves the quality of images, especially screenshots.
@@ -154,7 +155,6 @@
 - [Claude Code Video Toolkit](https://github.com/digitalsamba/claude-code-video-toolkit) — AI-native video production workspace for Claude Code with Remotion, ElevenLabs, FFmpeg, and Playwright skills.
 - [VideoDB Skills](https://github.com/video-db/skills) - See, understand, and act on video & audio — ingest, search, edit, generate, and stream media via VideoDB.
 - [moltdj](https://github.com/polaroteam/moltdj-skill) - AI music and podcast platform for autonomous agents — generate tracks, discover, earn tips and royalties.
-- [claude-code-mix-compare](https://github.com/gyujeongion/claude-code-mix-compare) - git diff for audio mixes: time-align two versions and phase-invert to show what actually changed, per stem and per band.
 - [claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills) - Claude Code plugin for AI music creation covering lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.
 - [creative-director-skill](https://github.com/smixs/creative-director-skill) - AI creative director for ideation, scoring, recursive refinement, and storytelling frameworks.
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@
 - [swarmclaw](https://github.com/swarmclawai/swarmclaw/blob/main/skills/swarmclaw.md) - Drive a self-hosted multi-agent runtime for delegating work across coding CLIs.
 - [upload-post](https://github.com/Upload-Post/upload-post-skill) - Publish and schedule media across 10+ social platforms from a single agent workflow.
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
+- [claude-code-council](https://github.com/gyujeongion/claude-code-council) - Claude chairs a panel of Gemini and GPT through your logged-in CLIs (no API keys) and reconciles a second opinion.
+- [claude-code-rootcause](https://github.com/gyujeongion/claude-code-rootcause) - Turns "never do X" bans into positive process gates, and audits your instruction file for ban bloat.
+- [claude-code-sandbox-gate](https://github.com/gyujeongion/claude-code-sandbox-gate) - A verification gate before a change hits main, so the agent can't ship an "it works now" patch unchecked.
+- [claude-code-request-modes](https://github.com/gyujeongion/claude-code-request-modes) - Classifies each request and activates only the rules that apply, so one global rulebook stops bleeding into everything.
+- [claude-code-cold-tester](https://github.com/gyujeongion/claude-code-cold-tester) - Runs a doc through a zero-context model to find where a real newcomer would get stuck.
+- [claude-code-goal-loop](https://github.com/gyujeongion/claude-code-goal-loop) - Autonomous goal loop with per-iteration verification, rollback snapshots, and stall detection.
 
 
 ## 📊 Data & Analysis
@@ -148,6 +154,7 @@
 - [Claude Code Video Toolkit](https://github.com/digitalsamba/claude-code-video-toolkit) — AI-native video production workspace for Claude Code with Remotion, ElevenLabs, FFmpeg, and Playwright skills.
 - [VideoDB Skills](https://github.com/video-db/skills) - See, understand, and act on video & audio — ingest, search, edit, generate, and stream media via VideoDB.
 - [moltdj](https://github.com/polaroteam/moltdj-skill) - AI music and podcast platform for autonomous agents — generate tracks, discover, earn tips and royalties.
+- [claude-code-mix-compare](https://github.com/gyujeongion/claude-code-mix-compare) - git diff for audio mixes: time-align two versions and phase-invert to show what actually changed, per stem and per band.
 - [claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills) - Claude Code plugin for AI music creation covering lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.
 - [creative-director-skill](https://github.com/smixs/creative-director-skill) - AI creative director for ideation, scoring, recursive refinement, and storytelling frameworks.
 

--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@
 - [swarmclaw](https://github.com/swarmclawai/swarmclaw/blob/main/skills/swarmclaw.md) - Drive a self-hosted multi-agent runtime for delegating work across coding CLIs.
 - [upload-post](https://github.com/Upload-Post/upload-post-skill) - Publish and schedule media across 10+ social platforms from a single agent workflow.
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
+- [claude-code-cold-tester](https://github.com/gyujeongion/claude-code-cold-tester) - Runs a doc through a zero-context model to find where a real newcomer would get stuck.
 - [claude-code-council](https://github.com/gyujeongion/claude-code-council) - Claude chairs a panel of Gemini and GPT through your logged-in CLIs (no API keys) and reconciles a second opinion.
+- [claude-code-goal-loop](https://github.com/gyujeongion/claude-code-goal-loop) - Autonomous goal loop with per-iteration verification, rollback snapshots, and stall detection.
+- [claude-code-request-modes](https://github.com/gyujeongion/claude-code-request-modes) - Classifies each request and activates only the rules that apply, so one global rulebook stops bleeding into everything.
 - [claude-code-rootcause](https://github.com/gyujeongion/claude-code-rootcause) - Turns "never do X" bans into positive process gates, and audits your instruction file for ban bloat.
 - [claude-code-sandbox-gate](https://github.com/gyujeongion/claude-code-sandbox-gate) - A verification gate before a change hits main, so the agent can't ship an "it works now" patch unchecked.
-- [claude-code-request-modes](https://github.com/gyujeongion/claude-code-request-modes) - Classifies each request and activates only the rules that apply, so one global rulebook stops bleeding into everything.
-- [claude-code-cold-tester](https://github.com/gyujeongion/claude-code-cold-tester) - Runs a doc through a zero-context model to find where a real newcomer would get stuck.
-- [claude-code-goal-loop](https://github.com/gyujeongion/claude-code-goal-loop) - Autonomous goal loop with per-iteration verification, rollback snapshots, and stall detection.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
A small family of Claude Code skills I built and use — all MIT, each in its own repo with a README and examples.

**Development & Code Tools**: council (Claude chairs Gemini + GPT, no API keys), rootcause (turn bans into positive gates + audit instruction bloat), sandbox-gate (verify before a change hits main), request-modes (activate only the rules a request needs), cold-tester (zero-context doc tester), goal-loop (autonomous loop with verification + rollback).

**Media & Content**: mix-compare (git diff for audio mixes — time-align two versions, phase-invert the change).

Added in the matching categories following the existing format. They're newer projects, so feel free to include only the subset that fits your bar. Thanks for maintaining this list!