### PR TITLE
add remote openclaw under collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@
 - [skills-for-humanity](https://github.com/human-avatar/skills-for-humanity) - Structured reasoning methodology skills for logic, decisions, creativity, ethics, writing, and strategy.
 - [superseo-skills](https://github.com/inhouseseo/superseo-skills) - SEO skill collection for audits, briefs, article writing, E-E-A-T, topic clusters, and link building.
 - [toprank](https://github.com/nowork-studio/toprank) - SEO and Google Ads skills for audits, metadata, schema, bids, and CMS fixes.
+- [Remote OpenClaw](https://www.remoteopenclaw.com/skills) - searchable directory of agent skills and mcp servers across OpenClaw, Hermes, Claude Code and Codex
 
 
 ## 🤝 Contribution


### PR DESCRIPTION
hey! adding remote openclaw to the collections section. it's a searchable directory that pulls together skills and mcp servers across openclaw, hermes, claude code and codex, so it felt at home next to the other collections you've got here. thanks for keeping this maintained.