### PR TITLE
Add penthera to Security & Web Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@
 - [webapp-testing](https://github.com/anthropics/skills/tree/main/skills/webapp-testing) - Toolkit for interacting with and testing local web applications using Playwright.
 - [ironclaw-agent-guard](https://github.com/wd041216-bit/ironclaw-agent-guard) - Security review skill and CLI/MCP companion for risky tool calls, prompt injection, secret redaction, and audit-friendly agent workflows.
 - [shellward-security-guide](https://github.com/jnMetaCode/shellward/tree/main/skills/security-guide) - AI agent security guide for prompt injection, DLP, dangerous command blocking, and PII scanning.
+- [penthera](https://github.com/danoszz/penthera) - Security scanner for web apps: scan a live URL or repo for TLS, headers, auth, secrets, IDOR/OAuth, and injection issues, mapped to OWASP with SARIF output. Runs as a skill or CLI.
 
 
 


### PR DESCRIPTION
Adds **penthera** to the Security & Web Testing section.

Penthera is an open-source security scanner that runs as an agent skill (Claude Code, Cursor) and a CLI. It scans a live URL or local repo for TLS, security headers, CORS, endpoint and OpenAPI discovery, JWT, auth hardening, IDOR/OAuth, injection issues, and hardcoded secrets, maps findings to OWASP WSTG, and exports SARIF for GitHub Security.

It fits alongside the other security skills here (VibeSec, owasp-security, ffuf) and is aimed at catching the common gaps in AI-coded apps before they ship.

- Repo: https://github.com/danoszz/penthera
- Install: `npx skills add danoszz/penthera`

For authorized, defensive testing only.
