### PR TITLE
Add BankBridge skills to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@
 
 
 ## 📊 Data & Analysis
+- [bankbridge](https://github.com/bankbridge-money/bankbridge-skills) - 19 read-only personal-finance slash commands wrapping a hosted MCP server — balances, monthly cashflow, subscriptions audit, recurring detection, tax prep, budget draft, fraud check, portfolio health. Reads real bank accounts via Plaid; no financial data cached.
 - [csv-data-summarizer-claude-skill](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSVs: columns, distributions, missing data, correlations.
 - [notebooklm](https://github.com/sanjay3290/ai-skills/tree/main/skills/notebooklm) - Query and manage Google NotebookLM notebooks with persistent auth, batch/multi queries, source sync, and structured exports.
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security.


### PR DESCRIPTION
Adds **BankBridge** to the 📊 Data & Analysis section.

19 read-only personal-finance slash commands wrapping a hosted MCP server. nothing cached. Commands cover balances, monthly cashflow, subscription auditing, recurring detection, tax prep, budget drafting, fraud checks, portfolio health.

- Skills repo: https://github.com/bankbridge-money/bankbridge-skills
- Plugin: https://github.com/bankbridge-money/bankbridge-plugin
- Site: https://bankbridge.money
- Also on the Official MCP Registry as \`money.bankbridge/server\`
