### PR TITLE
Add b2-cloud-storage skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [swarmclaw](https://github.com/swarmclawai/swarmclaw/blob/main/skills/swarmclaw.md) - Drive a self-hosted multi-agent runtime for delegating work across coding CLIs.
 - [upload-post](https://github.com/Upload-Post/upload-post-skill) - Publish and schedule media across 10+ social platforms from a single agent workflow.
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
+- [b2-cloud-storage](https://github.com/backblaze-labs/claude-skill-b2-cloud-storage) - Manage Backblaze B2 cloud storage from the terminal: list buckets, audit usage, detect stale or large objects, review security posture, and safely clean up data.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
Adds the Backblaze B2 Cloud Storage skill under Development & Code Tools.

- Repo: https://github.com/backblaze-labs/claude-skill-b2-cloud-storage (MIT)
- Manages Backblaze B2 from the terminal: list, audit usage, detect stale/large objects, security review, and safe cleanup.
- Built on the open Agent Skills SKILL.md spec; works with Claude Code and other compatible agents.