### PR TITLE
Add Mamba Labs GTM Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@
 - [skills-for-humanity](https://github.com/human-avatar/skills-for-humanity) - Structured reasoning methodology skills for logic, decisions, creativity, ethics, writing, and strategy.
 - [superseo-skills](https://github.com/inhouseseo/superseo-skills) - SEO skill collection for audits, briefs, article writing, E-E-A-T, topic clusters, and link building.
 - [toprank](https://github.com/nowork-studio/toprank) - SEO and Google Ads skills for audits, metadata, schema, bids, and CMS fixes.
+- [mamba-labs-skills](https://github.com/mambalabsdev/mamba-labs-skills) - 4 free GTM skills for signal-based outbound: ICP definition, cold email auditing, domain health checks, and hiring signal detection. Works with Claude Code, Codex CLI, Cursor, and MCP-compatible agents.
 
 
 ## 🤝 Contribution


### PR DESCRIPTION
Adding [Mamba Labs GTM Skills](https://github.com/mambalabsdev/mamba-labs-skills), a collection of 4 free, MIT-licensed GTM skills for signal-based outbound workflows.

Skills included:
- **ICP Definition Builder**: Guided interview that outputs a structured ICP block for Clay, CRM filters, or targeting briefs.
- **Cold Email Structure Checker**: Audits cold email drafts against a 7-point framework with pass/fail scorecard and revised version.
- **Domain Health Pre-Check**: Scans SPF, DKIM, DMARC, and blacklist status via the Mamba Labs Domain Deliverability Checker MCP server.
- **Hiring Signal Spotter**: Detects GTM hiring signals on Greenhouse, Lever, and Ashby via the Mamba Labs GTM Hiring Signal Scraper MCP server.

Compatible with Claude Code, Codex CLI, Cursor, Gemini CLI, and MCP-compatible agents. Each skill includes YAML frontmatter with name, description, license, metadata (category + tags), compatibility, and version fields. The repo ships with a `.claude-plugin/marketplace.json` manifest.
