### PR TITLE
Add Riffkit to Media & Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@
 - [deapi-ai/claude-code-skills](https://github.com/deapi-ai/claude-code-skills) - AI media toolkit: generate images (Flux), text-to-speech, transcribe YouTube/audio, OCR, video generation, upscale, and remove backgrounds via deAPI. Works with Cursor, Windsurf & Continue.dev.
 - [Claude Code Video Toolkit](https://github.com/digitalsamba/claude-code-video-toolkit) — AI-native video production workspace for Claude Code with Remotion, ElevenLabs, FFmpeg, and Playwright skills.
 - [VideoDB Skills](https://github.com/video-db/skills) - See, understand, and act on video & audio — ingest, search, edit, generate, and stream media via VideoDB.
+- [riffkit](https://github.com/riffkit/skill) - Riff a winning TikTok into your own short video: study a proven video's emotion formula and recreate it with your product, character, and language (EN/ES) via a hosted AI backend.
 - [moltdj](https://github.com/polaroteam/moltdj-skill) - AI music and podcast platform for autonomous agents — generate tracks, discover, earn tips and royalties.
 - [claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills) - Claude Code plugin for AI music creation covering lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.
 - [creative-director-skill](https://github.com/smixs/creative-director-skill) - AI creative director for ideation, scoring, recursive refinement, and storytelling frameworks.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@
 - [deapi-ai/claude-code-skills](https://github.com/deapi-ai/claude-code-skills) - AI media toolkit: generate images (Flux), text-to-speech, transcribe YouTube/audio, OCR, video generation, upscale, and remove backgrounds via deAPI. Works with Cursor, Windsurf & Continue.dev.
 - [Claude Code Video Toolkit](https://github.com/digitalsamba/claude-code-video-toolkit) — AI-native video production workspace for Claude Code with Remotion, ElevenLabs, FFmpeg, and Playwright skills.
 - [VideoDB Skills](https://github.com/video-db/skills) - See, understand, and act on video & audio — ingest, search, edit, generate, and stream media via VideoDB.
-- [riffkit](https://github.com/riffkit/skill) - Riff a winning TikTok into your own short video: study a proven video's emotion formula and recreate it with your product, character, and language (EN/ES) via a hosted AI backend.
+- [riffkit](https://github.com/riffkit/skill) - Riff a winning TikTok into your own short video: study a proven video's emotion formula and recreate it with your product, character, and language (EN/ES) via a hosted AI backend (account required).
 - [moltdj](https://github.com/polaroteam/moltdj-skill) - AI music and podcast platform for autonomous agents — generate tracks, discover, earn tips and royalties.
 - [claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills) - Claude Code plugin for AI music creation covering lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.
 - [creative-director-skill](https://github.com/smixs/creative-director-skill) - AI creative director for ideation, scoring, recursive refinement, and storytelling frameworks.


### PR DESCRIPTION
Adds **Riffkit** — an agent skill for recreating the *formula* of a winning short video.

Riffkit takes one proven short video, studies the hook, pacing, and emotional beats that made it retain viewers, and generates a brand-new video around the user's own product, character, and language (English/Spanish). It never re-uploads the source; the output is an original.

- Open-source skill spec (MIT): https://github.com/riffkit/skill
- Live skill + examples: https://riffkit.ai/SKILL.md
- Rendering runs on Riffkit's hosted backend (account required), consistent with other hosted entries already in the list.

One entry, added to the **Media & Content** section in the existing format.
