### PR TITLE
Add zillow-skills to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@
 - [dexpaprika-api](https://github.com/coinpaprika/skills/tree/main/dexpaprika-api) - Free DEX data across 34 chains: 30M+ pools, 27M+ tokens, real-time SSE streaming, OHLCV. No API key, no rate limits.
 - [gh-star-history](https://github.com/ykdojo/gh-star-history) - Visualize and compare GitHub star history as interactive charts, with regional breakdown of stargazers.
 - **[youtube-full](https://github.com/ZeroPointRepo/youtube-skills)** - YouTube transcripts, search, channel data, and playlists via TranscriptAPI. 100 free credits.
+- **[zillow-skills](https://github.com/ZeroPointRepo/zillow-skills)** - Zillow property data agent skills — Zestimate, listings, photos, schools, taxes, price history — via the Zillapi REST API. MIT-0, free tier.
 - [alpha-insights](https://github.com/Ericyoung-183/alpha-insights) - Structured business research skill with strategy frameworks, evidence grading, and report output.
 - [claude-persona](https://github.com/takechanman1228/claude-persona) - Build AI persona panels for customer research, interviews, concept tests, and executive reports.
 


### PR DESCRIPTION
Adds zillow-skills, matching the style of the existing zillow-skills sibling entry (youtube-full) right above it.

Zillow property data agent skills — Zestimate, listings, photos, schools, taxes, price history — via the Zillapi REST API. MIT-0, free tier.

Repo: https://github.com/ZeroPointRepo/zillow-skills