### PR TITLE
Add Reef small-business skills collection (12 skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@
 - [skills-for-humanity](https://github.com/human-avatar/skills-for-humanity) - Structured reasoning methodology skills for logic, decisions, creativity, ethics, writing, and strategy.
 - [superseo-skills](https://github.com/inhouseseo/superseo-skills) - SEO skill collection for audits, briefs, article writing, E-E-A-T, topic clusters, and link building.
 - [toprank](https://github.com/nowork-studio/toprank) - SEO and Google Ads skills for audits, metadata, schema, bids, and CMS fixes.
+- [Reef Small-Business Skills](https://github.com/buildwithreef/claude-skills) - 12 small-business skills: invoice chasing, Google/Yelp review replies, GBP and local SEO audits, landing-page teardowns, service pages, cold email, proposals, and a jargon-stripping rewrite mode. Each is a real SOP with checklists and templates.
 
 
 ## 🤝 Contribution


### PR DESCRIPTION
Adding a collection of 12 MIT-licensed skills built for small-business operations, written as real SOPs (escalation ladders, audit checklists, named formulas) rather than persona prompts.

- Repo: https://github.com/buildwithreef/claude-skills
- Each skill: SKILL.md + reference files where needed, installable via `npx skills add buildwithreef/claude-skills`
- Docs/examples for every skill: https://buildwithreef.com/skills/

Added to the Collections section following the existing entry format. Happy to adjust if you'd prefer individual skill entries in the topic sections instead.