### PR TITLE
Add mowgli skill to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [swarmclaw](https://github.com/swarmclawai/swarmclaw/blob/main/skills/swarmclaw.md) - Drive a self-hosted multi-agent runtime for delegating work across coding CLIs.
 - [upload-post](https://github.com/Upload-Post/upload-post-skill) - Publish and schedule media across 10+ social platforms from a single agent workflow.
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
+- [mowgli](https://github.com/mowgli-ai/skills) - Iterate on your product's design on an intelligent canvas: turn a frontend or GitHub repo into editable React + Tailwind screens, redesign them in natural language with full product context, and sync the results back to code.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
Adds [mowgli](https://github.com/mowgli-ai/skills) to the Development & Code Tools section.

Mowgli is an intelligent product canvas that connects to coding agents (Claude Code, Cursor, Codex, Antigravity) as an Agent Skill, with MCP as a fallback. It turns an existing frontend or GitHub repo into pixel-perfect, editable React + Tailwind designs, lets you iterate on them in natural language with full product context (user journeys, navigation, every screen state), and syncs the results back to the codebase.

Install: `npx skills add mowgli-ai/skills`

Disclosure: I work on Mowgli, and this PR was prepared with the help of Claude Code. It has been fully reviewed by me prior to submission.