### PR TITLE
Add ai-meeting skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@
 
 ## 🤝 Collaboration & Project Management
 - [agent-manager-skill](https://github.com/fractalmind-ai/agent-manager-skill) - Manage multiple local CLI AI agents via tmux sessions (start/stop/monitor/assign) with cron-friendly scheduling; no server required.
+- [ai-meeting](https://github.com/bin1874/ai-meeting-skill) - Organize structured AI meetings with Codex and Claude, preserving per-agent sessions across rounds and generating sourced final reports.
 - [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/git-pushing) - Automate git operations and repository interactions.
 - [kanban-skill](https://github.com/mattjoyce/kanban-skill) - Markdown-based Kanban board with file-based cards, YAML frontmatter for status/priority/dependencies, and no database required.
 - [linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams with MCP tools, SDK scripts, and GraphQL fallbacks for reliable project tracking.


### PR DESCRIPTION
Adds bin1874/ai-meeting-skill to the directory.

ai-meeting is an open-source skill and CLI workflow for running structured multi-agent meetings with Codex and Claude, preserving per-agent sessions across rounds and generating sourced final reports.

Validation:
- Ran `git diff --check`.