### PR TITLE
Add novel-to-webnovel (Writing & Research)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@
 - [avoid-ai-writing](https://github.com/conorbronsdon/avoid-ai-writing) - Audits and rewrites content to remove 21 categories of AI writing patterns with a 43-entry replacement table and two-pass detection.
 - [naming](https://github.com/glacierphonk/naming) - Metaphor-driven naming for products, SaaS, brands, bots, and open source projects. Structured process that produces memorable, meaningful names.
 - [ru-text](https://github.com/talkstream/ru-text) - Russian text quality: ~1,040 rules for typography, info-style, editorial, UX writing, business correspondence
+- [novel-to-webnovel](https://github.com/aimerfeng/novel-to-webnovel) - Convert translated-novel prose (JP light novels, MTL drafts) into natural Chinese webnovel style via a five-stage pipeline: format cleanup scripts, per-project style guides, parallel chunked rewriting, and QA checks.
 - [md2wechat](https://github.com/geekjourneyx/md2wechat-skill) - Convert Markdown into WeChat Official Account drafts with preview, image, and cover handling.
 - [buyer-eval](https://github.com/salespeak-ai/buyer-eval-skill) - Evaluate B2B vendors by interrogating agents, checking claims, and scoring weighted criteria.
 


### PR DESCRIPTION
## What

Adds [novel-to-webnovel](https://github.com/aimerfeng/novel-to-webnovel) to the **✍️ Writing & Research** section.

## Why it's useful

A Claude Code skill that converts translated-novel prose (Japanese light-novel translations, MTL drafts, or the user's own manuscripts) into natural Chinese webnovel style. It's built around a five-stage pipeline rather than a single prompt:

1. Deterministic format cleanup via bundled Perl scripts (CJK quote conversion, furigana removal, indent normalization)
2. Per-project style-guide generation from a template (3 intensity levels: light polish / webnovel voice / full localization)
3. User-approved writing sample before scaling up
4. Parallel subagent rewriting in ~25KB chunks with battle-tested dispatch templates (chunk-boundary handling, missing-chunk re-dispatch)
5. QA scripts + merge checklist (leftover punctuation/furigana detection, character-name consistency, slang-density limits)

Includes translation-ese removal tables and a curated webnovel-slang whitelist/blacklist. The 3 Perl tools also work standalone outside Claude. MIT licensed, follows the official progressive-disclosure skill structure (SKILL.md + references/ + scripts/ + assets/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)