### PR TITLE
Add seldonframe-agent-business (build → sell → get paid for AI agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
 - [plugin-authoring](https://github.com/ivan-magda/claude-code-plugin-template/tree/main/plugins/plugin-development/skills/plugin-authoring) - Ambient guidance for creating, modifying, and debugging Claude Code plugins with schemas, templates, validation workflows, and troubleshooting.
 - [azure-devops](https://github.com/sanjay3290/ai-skills/tree/main/skills/azure-devops) - Manage Azure DevOps projects, repos, PRs, pipelines, and work items via REST API.
 - [claude-skills](https://github.com/jeffallan/claude-skills) - 65 full-stack development skills with progressive disclosure, covering React, NestJS, Python, DevOps, and 30+ frameworks.
+- [seldonframe-agent-business](https://github.com/seldonframe/seldonframe/tree/main/skills/seldonframe-agent-business) - Build, eval-gate, deploy, and sell AI agents for real businesses from your IDE via the SeldonFrame MCP: build → test → deploy → sell → get paid.
 - [jules](https://github.com/sanjay3290/ai-skills/tree/main/skills/jules) - Delegate coding tasks to Google Jules AI agent for async bug fixes, documentation, tests, and feature implementation on GitHub repos.
 - [hashicorp-agent-skills](https://github.com/hashicorp/agent-skills) - HashiCorp-maintained Claude skills for Terraform workflows and infrastructure automation.
 - [agnix](https://github.com/avifenesh/agnix) - Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP configs, and more with 156 rules, auto-fix, and LSP server for real-time editor diagnostics.


### PR DESCRIPTION
`seldonframe-agent-business` teaches an IDE agent (Claude Code, Cursor, Codex) the complete agent-business loop on SeldonFrame: build an AI agent for a real business from one sentence, test it against the 8-scenario eval suite that gates publishing at ≥ 87.5%, deploy it to a real channel with the human-only connect step handled honestly, list it on the marketplace with per-call or per-outcome usage pricing, and withdraw the earnings. Every tool name is grounded in the real `@seldonframe/mcp` tool surface — no invented tools — including a table of the names agents typically guess wrong. Guardrails: the agent never collects secret keys in chat and never moves real money (payouts, phone provisioning, price changes) without an explicit human ask. First workspace is free with no API key; keys are requested progressively only when a verb needs them.