### PR TITLE
Add agent-codebase-skills to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@
 - [skills-for-humanity](https://github.com/human-avatar/skills-for-humanity) - Structured reasoning methodology skills for logic, decisions, creativity, ethics, writing, and strategy.
 - [superseo-skills](https://github.com/inhouseseo/superseo-skills) - SEO skill collection for audits, briefs, article writing, E-E-A-T, topic clusters, and link building.
 - [toprank](https://github.com/nowork-studio/toprank) - SEO and Google Ads skills for audits, metadata, schema, bids, and CMS fixes.
+- [agent-codebase-skills](https://github.com/Zrzzzz/agent-codebase-skills) - Three skills for long-lived codebases: AGENTS.md/CLAUDE.md layered conventions, auto session-notes hook, and concurrent-safe multi-agent task management.
 
 
 ## 🤝 Contribution


### PR DESCRIPTION
Adds [agent-codebase-skills](https://github.com/Zrzzzz/agent-codebase-skills) to the 🗂️ Collections section.

A set of three independent, idempotent Claude Code skills for keeping agents effective in large, long-lived codebases:

- **init-agents-md** — layered memory conventions in AGENTS.md / CLAUDE.md (with nested per-module memory for monorepos, and a migrate mode for existing CLAUDE.md files)
- **init-session-notes** — SessionEnd hook that auto-distills each session into 3–8 takeaways in docs/session-notes.md, with LLM compaction past 45 KB
- **init-agent-task-md** — file-per-task task management designed for concurrent agents (atomic mkdir-lock ID allocation, regenerated TASKS.md index, lifecycle tied to git branches)

MIT licensed; installable as a Claude Code plugin or via a one-line script; includes an examples/ snapshot of the generated output. Entry follows the existing format and is appended at the end of the section.