### PR TITLE
Add routerbase agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) - Specification-driven development skill that turns requirements into blueprints, build plans, and validated implementations.
 - [harness-evolver](https://github.com/raphaelchristi/harness-evolver) - Evolve agent prompts, routing, tools, and architecture with LangSmith-backed regression guards.
 - [qdrant-skills](https://github.com/qdrant/skills) - Agent skills for Qdrant vector search operations, performance, deployment, upgrades, and SDK usage.
+- [routerbase-agent-skills](https://github.com/zenlee123/routerbase-agent-skills) - Agent skills for using [routerbase](https://routerbase.com/) as an OpenAI-compatible API gateway, model routing layer, and media generation interface.
 - [skill-optimizer](https://github.com/hqhq1025/skill-optimizer) - Diagnose and improve Agent Skills using session data and static analysis.
 - [swarmclaw](https://github.com/swarmclawai/swarmclaw/blob/main/skills/swarmclaw.md) - Drive a self-hosted multi-agent runtime for delegating work across coding CLIs.
 - [upload-post](https://github.com/Upload-Post/upload-post-skill) - Publish and schedule media across 10+ social platforms from a single agent workflow.


### PR DESCRIPTION
Adds the public routerbase-agent-skills repository to Development & Code Tools.

The repository includes three SKILL.md-based agent skills for RouterBase API integration, model routing, and media generation. The entry links to the GitHub skill repository and includes the routerbase website as the product reference.