### PR TITLE
Add ai-net-doctor (network diagnostics for Codex/Claude)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@
 - [pua](https://github.com/tanweai/pua) - Corporate motivation skill that pushes AI agents to exhaust options before giving up.
 - [sequenzy-email-marketing](https://clawhub.ai/polnikale/sequenzy-email-marketing) - Operate Sequenzy email marketing workflows for subscribers, campaigns, sequences, and templates.
 - [TweetClaw](https://github.com/Xquik-dev/tweetclaw) - X/Twitter automation skill for search, posting, follower export, monitors, webhooks, and giveaways.
+- [ai-net-doctor](https://github.com/wxggzz/ai-net-doctor) - Diagnoses whether your network can actually reach Codex/OpenAI and Claude/Anthropic, pinpointing the first broken layer (DNS/TCP/TLS/HTTP/auth/proxy) and telling real network failures apart from auth/quota. Ships a /network-doctor Claude Code skill that only calls the CLI.
 
 ## 📰 Articles & Blog Posts
 


### PR DESCRIPTION
Adds **ai-net-doctor** under **Utility & Automation**.

A single-binary Go CLI that diagnoses whether the network can actually reach Codex/OpenAI and Claude/Anthropic, localizing the first broken layer (DNS/TCP/TLS/HTTP/auth/proxy) and distinguishing real network failures from auth/quota issues. Ships a `/network-doctor` Claude Code skill (in-repo under `integrations/`) that only calls the CLI and never re-derives the verdict.

- Repo: https://github.com/wxggzz/ai-net-doctor
- Local-only, no telemetry; MIT; CI + tests.