### PR TITLE
Add alphai-claude-skills (Data & Analysis)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@
 - **[youtube-full](https://github.com/ZeroPointRepo/youtube-skills)** - YouTube transcripts, search, channel data, and playlists via TranscriptAPI. 100 free credits.
 - [alpha-insights](https://github.com/Ericyoung-183/alpha-insights) - Structured business research skill with strategy frameworks, evidence grading, and report output.
 - [claude-persona](https://github.com/takechanman1228/claude-persona) - Build AI persona panels for customer research, interviews, concept tests, and executive reports.
+- [alphai-claude-skills](https://github.com/makeev/alphai-claude-skills) - Financial-market workflows on the AlphaAI MCP: market pulse, single-stock briefs, SEC Form 4 insider radar, two-ticker read-across, and news-alert management over relevance-scored, ticker-linked news. Free tier, OAuth — no key to paste.
 
 
 ## 🔬 Scientific & Research Tools


### PR DESCRIPTION
Adds [alphai-claude-skills](https://github.com/makeev/alphai-claude-skills) to **📊 Data & Analysis** — five documented SKILL.md workflows for the hosted AlphaAI financial-news MCP (`mcp.alphai.io`): market pulse, single-stock situational briefs, SEC Form 4 insider radar, two-ticker read-across, and news-alert management. News comes relevance-scored (1-10) and ticker-linked; insider data is parsed from SEC EDGAR Form 4 filings. Tested in Claude Code against the live server (OAuth 2.1; free tier 100 calls/day, no card). Follows the existing entry format.