### PR TITLE
Add Superdesign to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [swarmclaw](https://github.com/swarmclawai/swarmclaw/blob/main/skills/swarmclaw.md) - Drive a self-hosted multi-agent runtime for delegating work across coding CLIs.
 - [upload-post](https://github.com/Upload-Post/upload-post-skill) - Publish and schedule media across 10+ social platforms from a single agent workflow.
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
+- [Superdesign](https://github.com/superdesigndev/superdesign-skill) - A design skill for coding agents that sets up a design system from your codebase, then generates and iterates UI drafts on an infinite canvas.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
Adds [Superdesign](https://github.com/superdesigndev/superdesign-skill), a design skill for coding agents (Claude Code, Cursor and others) that sets up a design system from your codebase and generates/iterates UI drafts on an infinite canvas.

- Installable across 70+ agents via `npx skills add superdesigndev/superdesign-skill`
- MIT licensed, single entry, placed in Development & Code Tools alongside the other UI/UX skills
- Not already on the list (checked)

Disclosure: I maintain Superdesign.