### PR TITLE
Add human-html skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [swarmclaw](https://github.com/swarmclawai/swarmclaw/blob/main/skills/swarmclaw.md) - Drive a self-hosted multi-agent runtime for delegating work across coding CLIs.
 - [upload-post](https://github.com/Upload-Post/upload-post-skill) - Publish and schedule media across 10+ social platforms from a single agent workflow.
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
+- [human-html](https://github.com/rhnfzl/human-html) - Turn plans, reviews, architecture explainers, and postmortems into validated single-file HTML review surfaces humans actually read; ships an offline validator, auto-generated gallery, agent hooks, and optional S3 publishing.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
This adds human-html to the Development & Code Tools category. The skill turns plans, reviews, architecture explainers, and postmortems into validated single-file HTML review surfaces humans actually read, and ships an offline validator, an auto-generated gallery, agent hooks, and optional S3 publishing. Install it with `npx skills add rhnfzl/human-html`; a live example gallery is at https://rhnfzl.github.io/human-html/.