### PR TITLE
Add time-ledger and trading-ledger to Utility & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@
 - [pua](https://github.com/tanweai/pua) - Corporate motivation skill that pushes AI agents to exhaust options before giving up.
 - [sequenzy-email-marketing](https://clawhub.ai/polnikale/sequenzy-email-marketing) - Operate Sequenzy email marketing workflows for subscribers, campaigns, sequences, and templates.
 - [TweetClaw](https://github.com/Xquik-dev/tweetclaw) - X/Twitter automation skill for search, posting, follower export, monitors, webhooks, and giveaways.
+- [time-ledger](https://github.com/cruisekkk/time-ledger) - Log your time by telling Claude what you did in one sentence; it structures the activity, duration, and date into your own Notion database and asks when it's unsure instead of guessing.
+- [trading-ledger](https://github.com/cruisekkk/trading-ledger) - Journal trades in plain language — captures the entry reason, thesis, and emotion into a Notion database, links closes back to opens, and runs a weekly review of your decisions rather than P&L.
 
 ## 📰 Articles & Blog Posts
 


### PR DESCRIPTION
Adds two open-source (MIT) skills I've been using daily to the Utility & Automation section:

- **time-ledger** — you tell Claude what you did in a sentence ("read papers 2h, gym 1h") and it writes structured rows to your own Notion time database. The design rule I care about: when it's unsure it asks instead of inventing a duration.
- **trading-ledger** — same pattern for a trading journal: capture the *reason* for a trade at entry (thesis, plan, emotion), link the close back to the open, and review decisions weekly rather than P&L.

Both are self-report skills — no server, one SKILL.md + the official Notion connector + a template. Sister projects, cross-linked. Free to try; the Notion template also works as a plain manual ledger. Placed both alphabetically-adjacent in Utility & Automation.