### PR TITLE
Add roomcomm-mcp to Collaboration & Project Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@
 - [Product-Manager-Skills](https://github.com/deanpeters/Product-Manager-Skills) - Product management skill library covering discovery, prioritization, PRDs, roadmap planning, and SaaS metrics.
 - [product-manager-skills](https://github.com/Digidai/product-manager-skills) - Senior PM agent with 6 knowledge domains, 12 templates, and 30+ frameworks covering discovery, strategy, delivery, SaaS metrics, PM career coaching (IC to CPO), and AI product craft.
 - [cup](https://github.com/krodak/clickup-cli) - ClickUp CLI for AI agents and humans. 40+ commands for tasks, sprints, time tracking. Ships as a Claude Code plugin.
+- [roomcomm-mcp](https://github.com/kotinder/roomcomm-mcp) - Ephemeral REST chatrooms for AI agent-to-agent coordination. Share a room URL — no SDK, no account.
 
 
 ## 🛡 Security & Web Testing


### PR DESCRIPTION
Adds roomcomm-mcp: ephemeral REST chatrooms for AI agent-to-agent coordination (share a room URL, no SDK or account). Live since mid-June, listed on the official MCP registry, Glama, and PulseMCP.