### PR TITLE
Add deep-security-check (defensive security assessment skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@
 - [webapp-testing](https://github.com/anthropics/skills/tree/main/skills/webapp-testing) - Toolkit for interacting with and testing local web applications using Playwright.
 - [ironclaw-agent-guard](https://github.com/wd041216-bit/ironclaw-agent-guard) - Security review skill and CLI/MCP companion for risky tool calls, prompt injection, secret redaction, and audit-friendly agent workflows.
 - [shellward-security-guide](https://github.com/jnMetaCode/shellward/tree/main/skills/security-guide) - AI agent security guide for prompt injection, DLP, dangerous command blocking, and PII scanning.
+- [deep-security-check](https://github.com/give-jd/deep-security-check) - Read-only defensive security assessment: Semgrep SAST, osv-scanner SCA, and gitleaks secrets scanning with a reproducible 0-100 A-F grade.
 
 
 


### PR DESCRIPTION
Adds [deep-security-check](https://github.com/give-jd/deep-security-check) — a defensive, read-only security assessment skill for Claude Code. It runs Semgrep (SAST), osv-scanner (dependency CVEs) and gitleaks (secrets) against a local project and produces a report with a reproducible reliability grade (0-100, A-F) computed by a deterministic rubric, not model opinion.

- MIT licensed, static analysis only, never sends traffic to live targets
- Works standalone without Claude too
- v0.1.0 released: https://github.com/give-jd/deep-security-check/releases/tag/v0.1.0

Entry follows the existing format of the section. Thanks for maintaining the list!