### PR TITLE
Add doc-cleanup — agent-docs context-rot auditor

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [swarmclaw](https://github.com/swarmclawai/swarmclaw/blob/main/skills/swarmclaw.md) - Drive a self-hosted multi-agent runtime for delegating work across coding CLIs.
 - [upload-post](https://github.com/Upload-Post/upload-post-skill) - Publish and schedule media across 10+ social platforms from a single agent workflow.
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
+- [doc-cleanup](https://github.com/aka-luan/doc-cleanup) - Audits a repo's markdown docs for agent-context rot (completed-work logs, executed plans, stale facts, contradictions, dead paths), then archives history and rewrites live docs to code-verified current facts.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
Adds **[doc-cleanup](https://github.com/aka-luan/doc-cleanup)** to Development & Code Tools (MIT licensed).

It's a skill that audits a repo's markdown docs (CLAUDE.md / AGENTS.md and everything they make agents read each session) for context rot: completed-work checklists, executed plans still read as current intent, internal contradictions, facts the code outgrew, dead paths after machine migrations. Every finding is verified against the actual code before it's reported, and it never rewrites anything without explicit approval — history is archived verbatim, live docs are rewritten to re-verified facts.

First production run on a real monorepo cut agent required-reading from 1,085 to 266 lines (−75%) and caught six concrete traps (merged work still marked "awaiting merge", a table contradicted by its own footnote, a hard rule pointing at a Windows path on a WSL machine). Details and the full methodology are in the repo README.

Install: `npx skills add aka-luan/doc-cleanup` or copy `skills/doc-cleanup/SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
