### PR TITLE
Add Maoxuan Product Agent to Collaboration & Project Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@
 - [kanban-skill](https://github.com/mattjoyce/kanban-skill) - Markdown-based Kanban board with file-based cards, YAML frontmatter for status/priority/dependencies, and no database required.
 - [linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams with MCP tools, SDK scripts, and GraphQL fallbacks for reliable project tracking.
 - [linear-cli-skill](https://github.com/Valian/linear-cli-skill) - A skill teaching claude how to use linear-CLI (provided alongside the skill), meant to replace linear MCP.
+- [Maoxuan Product Agent](https://github.com/atdy/maoxuan-product-agent) - Chinese-first product decision skill that identifies the current bottleneck, stage, constraints, and next actions across 36 tested product, growth, operations, data, and collaboration scenarios.
 - [meeting-insights-analyzer](https://github.com/ComposioHQ/awesome-claude-skills/blob/master/meeting-insights-analyzer/) - Transforms your meeting transcripts into actionable insights about your communication patterns
 - [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/review-implementing) - Evaluate code implementation plans and align with specs.
 - [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/test-fixing) - Detect failing tests and propose patches or fixes.


### PR DESCRIPTION
## Summary

Adds [Maoxuan Product Agent](https://github.com/atdy/maoxuan-product-agent) to **Collaboration & Project Management**, alphabetically between `linear-cli-skill` and `meeting-insights-analyzer`.

## About the skill

A Chinese-first product decision Agent Skill for product managers, product owners, growth/operations teams, founders, and project leads. It identifies the current bottleneck, stage, dominant mechanism, evidence quality, constraints, and stakeholders before returning 1-3 concrete next actions, stop conditions, and strategy-switch signals.

It covers 36 tested scenarios including prioritization, Roadmaps, growth, retention, conversion, community/content operations, metric anomalies, A/B Tests, delays, executive interruptions, and cross-functional collaboration.

- 36/36 documented product cases pass the quality gate
- Four clean-session forward tests with Claude Code
- Supports Claude Code, Codex, Cursor, and the open Agent Skills format
- MIT licensed; no API key, hosted service, or paid dependency

The underlying workflow is distilled from *On Practice* and *On Contradiction*, while default output uses modern product language and does not quote source texts, teach history, or perform political role-play.

Live overview: https://atdy.github.io/maoxuan-product-agent/
Install: `npx skills add atdy/maoxuan-product-agent --skill product-decision-agent`

I am the author and maintainer of the submitted skill.