### PR TITLE
Add Agent Skills Hub to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@
 - [find-skills](https://github.com/agentbay-ai/agentbay-skills) - Helps users discover, search and install agent skills from the marketplace.
 - [OpenPaw](https://github.com/daxaur/openpaw) - 38-skill bundle that turns Claude Code into a personal assistant. Includes git, Telegram, Discord, Obsidian, daily briefing, and more. Run via `npx pawmode`.
 - [agentskill.sh](https://agentskill.sh) - Browse and install 69,000+ AI agent skills for Claude Code, Cursor, Copilot, Windsurf, Zed, and 20+ AI tools.
+- [Agent Skills Hub](https://agentskillshub.top) - Open directory of 130,000+ agent skills and MCP servers, each with a SAFE/CAUTION/UNSAFE security grade and quality score, refreshed every 8 hours.
 - [Agent Almanac](https://github.com/pjt222/agent-almanac) - 317 skills, 65 agents, and 14 teams for Claude Code following the Agent Skills open standard across 50+ domains.
 - [AlterLab-FC-Skills](https://github.com/AlterLab-IEU/AlterLab-FC-Skills) - 72 agentic skills for creative technology workflows across 11 domains.
 - [AlterLab-Academic-Skills](https://github.com/AlterLab-IEU/AlterLab-Academic-Skills) - 186+ academic research skills across 13 domains for higher education and research.


### PR DESCRIPTION
Adds [Agent Skills Hub](https://agentskillshub.top) to the Collections section — an open directory of 130,000+ agent skills and MCP servers where every entry carries a SAFE/CAUTION/UNSAFE security grade and a quality score (refreshed every 8 hours from GitHub).

Placed next to the other discovery entries. It's free, no login; code is MIT and the full graded dataset is open (CC-BY-4.0 on Hugging Face). Fits naturally with this list's Security & Web Testing focus — the grades let readers vet a skill before installing.

Happy to adjust wording or placement. Thanks for the list!