### PR TITLE
Add d2-diagrams (D2 diagram-as-code with self-checking render loop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
 - [agent-lsp](https://github.com/blackwell-systems/agent-lsp) - Semantic code intelligence skills for refactor, rename, impact analysis, and verification.
 - [agenttrace-session-audit](https://github.com/luoyuctl/agenttrace/tree/master/skills/agenttrace-session-audit) - Audit AI coding sessions for cost, failures, latency, diffs, and CI gates.
 - [aws-architecture-diagram-skill](https://github.com/vidanov/aws-architecture-diagram-skill) - Generate editable AWS architecture diagrams with verified icons and export formats.
+- [d2-diagrams](https://github.com/khollingworth/d2-diagram-skill) - Render professional D2 architecture diagrams (TALA/ELK) as SVG with a self-checking render loop that fixes layout defects before delivering.
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) - Specification-driven development skill that turns requirements into blueprints, build plans, and validated implementations.
 - [harness-evolver](https://github.com/raphaelchristi/harness-evolver) - Evolve agent prompts, routing, tools, and architecture with LangSmith-backed regression guards.
 - [qdrant-skills](https://github.com/qdrant/skills) - Agent skills for Qdrant vector search operations, performance, deployment, upgrades, and SDK usage.


### PR DESCRIPTION
Adds d2-diagrams next to the related aws-architecture-diagram-skill entry.

Claude Code skill/plugin that writes D2, renders SVG with the best available layout engine (TALA when licensed, ELK fallback), then views its own render and fixes layout defects in a loop before delivering. Architecture, sequence, ERD, C4, network and state-machine diagrams. MIT licensed, CI-tested.