### PR TITLE
Add claude-real-video to Media & Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@
 - [moltdj](https://github.com/polaroteam/moltdj-skill) - AI music and podcast platform for autonomous agents — generate tracks, discover, earn tips and royalties.
 - [claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills) - Claude Code plugin for AI music creation covering lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.
 - [creative-director-skill](https://github.com/smixs/creative-director-skill) - AI creative director for ideation, scoring, recursive refinement, and storytelling frameworks.
+- [claude-real-video](https://github.com/HUANGCHIHHUNGLeo/claude-real-video) - Lets Claude or any LLM actually watch a video: scene-aware, deduplicated keyframes plus a timestamped transcript from a URL or local file, processed locally.
 
 
 ## 🏥 Health & Life Sciences


### PR DESCRIPTION
Adds [claude-real-video](https://github.com/HUANGCHIHHUNGLeo/claude-real-video) to the Media & Content section.

What it is: a local CLI that lets Claude (or any LLM) actually watch a video — it extracts scene-aware, deduplicated keyframes and a timestamped transcript from a URL or local file, producing a folder any LLM can read. Ships a bundled Claude Code skill (skills/claude-real-video-for-agents/).

Why it fits: MIT licensed, ~1.4k GitHub stars, reached the Hacker News front page, and complements the existing video entries here (which cover downloading, transcripts, and generation, but not scene-aware frame extraction for LLM viewing).

Disclosure: I am the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)