### PR TITLE
Add higgsfield-trailer-finishing (Media & Content)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@
 - [moltdj](https://github.com/polaroteam/moltdj-skill) - AI music and podcast platform for autonomous agents — generate tracks, discover, earn tips and royalties.
 - [claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills) - Claude Code plugin for AI music creation covering lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.
 - [creative-director-skill](https://github.com/smixs/creative-director-skill) - AI creative director for ideation, scoring, recursive refinement, and storytelling frameworks.
+- [higgsfield-trailer-finishing](https://github.com/cindyxu1030/higgsfield-trailer-finishing) - Finish AI-generated clips into one delivered video: ffmpeg stitch, cinematic grade, and an original licensed soundtrack matched to the assembled cut (Sonilo video-to-music).
 
 
 ## 🏥 Health & Life Sciences


### PR DESCRIPTION
Adds [higgsfield-trailer-finishing](https://github.com/cindyxu1030/higgsfield-trailer-finishing) to Media & Content: an Agent Skill that finishes AI-generated clips into one delivered video — ffmpeg stitch, cinematic grade, and an original licensed soundtrack matched to the assembled cut (Sonilo video-to-music).

Disclosure: I work on Sonilo, which powers the soundtrack stage (user-supplied API key; stitch/grade/mux work without it).