### PR TITLE
Add Vox Director (Vox-style collage video skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@
 - [moltdj](https://github.com/polaroteam/moltdj-skill) - AI music and podcast platform for autonomous agents — generate tracks, discover, earn tips and royalties.
 - [claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills) - Claude Code plugin for AI music creation covering lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.
 - [creative-director-skill](https://github.com/smixs/creative-director-skill) - AI creative director for ideation, scoring, recursive refinement, and storytelling frameworks.
+- [Vox Director](https://github.com/Alisa0808/vox-director) - Turn one topic into a finished Vox-style paper-collage explainer/ad video — script, collage art, motion, voice-over, music & captions, automated on Atlas Cloud + ffmpeg. Works with Claude Code, Codex & any SKILL.md agent.
 
 
 ## 🏥 Health & Life Sciences


### PR DESCRIPTION
Adds **Vox Director** under 🎬 Media & Content.

Open-source (MIT) agent skill: turns one topic into a finished Vox-style paper-collage explainer/ad video — script, collage keyframes, motion, voice-over, music and captions — automated end to end (Atlas Cloud API + local ffmpeg). Works with Claude Code and any SKILL.md agent.

Repo: https://github.com/Alisa0808/vox-director