### PR TITLE
Add design-playbooks to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [swarmclaw](https://github.com/swarmclawai/swarmclaw/blob/main/skills/swarmclaw.md) - Drive a self-hosted multi-agent runtime for delegating work across coding CLIs.
 - [upload-post](https://github.com/Upload-Post/upload-post-skill) - Publish and schedule media across 10+ social platforms from a single agent workflow.
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
+- [design-playbooks](https://github.com/veryCoolTimo/design-playbooks-skill) - Evidence-based design rules for AI frontends synthesized from 407 real product sites: page playbooks with pattern frequencies, 9 style guides, per-site hex/type tokens, DESIGN.md generator.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
 Adds design-playbooks — evidence-based design rules for Claude Code synthesized from 407 real product sites. MIT, standard SKILL.md.