### PR TITLE
Add humanizer-ru for Russian AI-writing cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@
 - [ru-text](https://github.com/talkstream/ru-text) - Russian text quality: ~1,040 rules for typography, info-style, editorial, UX writing, business correspondence
 - [md2wechat](https://github.com/geekjourneyx/md2wechat-skill) - Convert Markdown into WeChat Official Account drafts with preview, image, and cover handling.
 - [buyer-eval](https://github.com/salespeak-ai/buyer-eval-skill) - Evaluate B2B vendors by interrogating agents, checking claims, and scoring weighted criteria.
+- [humanizer-ru](https://github.com/Vladimir-Human/humanizer-ru) - Audits and rewrites Russian text using 38 style patterns and 35 deterministic regex markers.
 
 
 ## 📘 Learning & Knowledge  


### PR DESCRIPTION
## Summary
Adds `Vladimir-Human/humanizer-ru` — a Russian AI-writing cleanup skill with 38 style patterns and 35 deterministic regex markers.

## Why it fits
- The list already contains English-focused AI-writing tools (`avoid-ai-writing`) and Russian text-quality tools (`ru-text`); this entry combines Russian-specific AI-writing cleanup with a deterministic audit
- MIT-licensed, portable across Claude Code, Codex, Cursor, Gemini CLI, and OpenCode
- 61 GitHub stars, 266+ installs on skills.sh
- No network service required; offline self-scan in CI

I checked the list and existing pull requests for the repository URL before submitting.