### PR TITLE
Add claude-video-plus to Media & Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@
 ## 🎬 Media & Content
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [video-downloader](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/video-downloader) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival.
+- [claude-video-plus](https://github.com/abe238/claude-video-plus) - Ask a video a question: retrieves only the chapters, numeric facts, and on-screen moments that answer it instead of sampling the whole timeline.
 - [image-enhancer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/image-enhancer) - Improves the quality of images, especially screenshots.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, and visual assets.
 - [elevenlabs](https://github.com/sanjay3290/ai-skills/tree/main/skills/elevenlabs) - Text-to-speech narration and two-host podcast generation from documents using ElevenLabs API.


### PR DESCRIPTION
Adds **claude-video-plus** to the 🎬 Media & Content section.

**What it does:** Ask a video a question and it retrieves only the chapters, numeric facts, and on-screen moments that answer it, instead of sampling the whole timeline.

**Install (universal):**
```
npx skills add abe238/claude-video-plus -g
```
Claude Code plugin:
```
/plugin marketplace add abe238/claude-video-plus
/plugin install watch@claude-video-plus
```

**Why it fits this list's quality bar:** A sealed, receipt-gated benchmark matched the original pipeline's blind-judged answer quality (8.83 vs 8.80) at ~56% fewer tokens. It ships 338 deterministic tests and fails open, reverting to the original pipeline on no captions, a local file, a short video, or any error.

**Attribution:** An attributed MIT fork of [bradautomates/claude-video](https://github.com/bradautomates/claude-video), with upstream authorship preserved.

Single-line addition, matches the existing entry format; the "Media & Content" heading already exists so the Table of Contents is unchanged.