### PR TITLE
Add ai-shortfilm-prompts to Media & Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@
 - [moltdj](https://github.com/polaroteam/moltdj-skill) - AI music and podcast platform for autonomous agents — generate tracks, discover, earn tips and royalties.
 - [claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills) - Claude Code plugin for AI music creation covering lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.
 - [creative-director-skill](https://github.com/smixs/creative-director-skill) - AI creative director for ideation, scoring, recursive refinement, and storytelling frameworks.
+- [ai-shortfilm-prompts](https://github.com/jnMetaCode/ai-shortfilm-prompts) - Turns any idea into a cinematic, model-ready video prompt for Sora/Kling/Veo/Seedance using a 5-stage structure distilled from a 13M-view AI short film; 21 genre templates, eval-tested.
 
 
 ## 🏥 Health & Life Sciences


### PR DESCRIPTION
Adds a skill that turns a scene idea into a cinematic, model-ready video prompt for Sora / Kling / Veo / Seedance 2.0 — same category as the existing video-prompting-skill entry.

- 5-stage prompt structure (core theme → character/scene → atmosphere → camera rules → per-shot storyboard) distilled from Mx-Shell's *Zombie Scavenger*, the AI short Hollywood director PJ Ace called "one of the best short films I've seen in years" (13.4M views)
- 21 genre templates (transformation, sci-fi, product ad, pet/family narrative, found-footage horror, etc.)
- Ships with an eval suite (`evals/` + CI) and IP-name safety handling for platforms like Seedance that reject named IP
- MIT licensed, bilingual (EN/中文) docs

Repo: https://github.com/jnMetaCode/ai-shortfilm-prompts