### PR TITLE
Add Ontoly to development tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@
 - [spartan-ai-toolkit](https://github.com/spartan-stratos/spartan-ai-toolkit) - Engineering workflow commands with quality gates, TDD enforcement, and atomic commits for AI coding agents.
 - [blueprint](https://github.com/imbue-ai/blueprint) - Planning copilot for coding agents. Explores the codebase, asks clarifying questions, then generates a markdown plan any agent can execute in one shot.
 - [agent-lsp](https://github.com/blackwell-systems/agent-lsp) - Semantic code intelligence skills for refactor, rename, impact analysis, and verification.
+- [Ontoly](https://github.com/0xsarwagya/ontoly) - Deterministic Software Graph, MCP server, and agent skills for codebase architecture, impact analysis, request tracing, and dependency analysis.
 - [agenttrace-session-audit](https://github.com/luoyuctl/agenttrace/tree/master/skills/agenttrace-session-audit) - Audit AI coding sessions for cost, failures, latency, diffs, and CI gates.
 - [aws-architecture-diagram-skill](https://github.com/vidanov/aws-architecture-diagram-skill) - Generate editable AWS architecture diagrams with verified icons and export formats.
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) - Specification-driven development skill that turns requirements into blueprints, build plans, and validated implementations.


### PR DESCRIPTION
## Summary
- Add Ontoly to the Development & Code Tools section.
- Link to the public Ontoly repository.

## Why
Ontoly provides a deterministic Software Graph, MCP server, and agent skills for codebase architecture, impact analysis, request tracing, and dependency analysis.

## Validation
- Ran `git diff --check`.
