### PR TITLE
Add Ontoly Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@
 - [spartan-ai-toolkit](https://github.com/spartan-stratos/spartan-ai-toolkit) - Engineering workflow commands with quality gates, TDD enforcement, and atomic commits for AI coding agents.
 - [blueprint](https://github.com/imbue-ai/blueprint) - Planning copilot for coding agents. Explores the codebase, asks clarifying questions, then generates a markdown plan any agent can execute in one shot.
 - [agent-lsp](https://github.com/blackwell-systems/agent-lsp) - Semantic code intelligence skills for refactor, rename, impact analysis, and verification.
+- [Ontoly Agent Skills](https://github.com/0xsarwagya/ontoly/tree/main/skills) - Use Ontoly's deterministic Software Graph and MCP capabilities for architecture summaries, route tracing, dependency analysis, configuration usage, and impact analysis before broad source search.
 - [agenttrace-session-audit](https://github.com/luoyuctl/agenttrace/tree/master/skills/agenttrace-session-audit) - Audit AI coding sessions for cost, failures, latency, diffs, and CI gates.
 - [aws-architecture-diagram-skill](https://github.com/vidanov/aws-architecture-diagram-skill) - Generate editable AWS architecture diagrams with verified icons and export formats.
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) - Specification-driven development skill that turns requirements into blueprints, build plans, and validated implementations.


### PR DESCRIPTION
## Summary
- Adds Ontoly Agent Skills to the Development & Code Tools section.
- Describes Ontoly as deterministic Software Graph/MCP evidence for architecture summaries, route tracing, dependency analysis, configuration usage, and impact analysis.

## Validation
- `git diff --check`

This is a README-only directory listing; no repository behavior is changed.