### PR TITLE
Add idea-hunt skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@
 - [ru-text](https://github.com/talkstream/ru-text) - Russian text quality: ~1,040 rules for typography, info-style, editorial, UX writing, business correspondence
 - [md2wechat](https://github.com/geekjourneyx/md2wechat-skill) - Convert Markdown into WeChat Official Account drafts with preview, image, and cover handling.
 - [buyer-eval](https://github.com/salespeak-ai/buyer-eval-skill) - Evaluate B2B vendors by interrogating agents, checking claims, and scoring weighted criteria.
+- [idea-hunt](https://github.com/ANVEAI/idea-hunt-skill) - Evidence-first AI business idea discovery and validation: finds a painful, already-paid-for workflow AI can replace, mines real pain, applies kill-gates, and forces a proof-of-wallet test before you build.
 
 
 ## 📘 Learning & Knowledge  


### PR DESCRIPTION
### Adding: idea-hunt

**Repo:** https://github.com/ANVEAI/idea-hunt-skill · MIT · single self-contained `SKILL.md` — no API key or paid subscription required to function.

**What it does:** Evidence-first AI business idea discovery & validation. It inverts the usual "invent an idea" prompt: it hunts for an existing, already-paid-for workflow AI can now do as *completed work*, then runs a 7-stage pipeline — pain mining → kill-gates → the Mom Test → a proof-of-wallet test — so weak ideas get rejected on paper before any build.

- [x] Actively maintained, documented (README + FAQ)
- [x] No commercial-API / paid-subscription dependency
- [x] Real value for Claude / Claude Code users
- [x] Concise, single-sentence description