### PR TITLE
Add kc_ai_skills collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@
 - [skills-for-humanity](https://github.com/human-avatar/skills-for-humanity) - Structured reasoning methodology skills for logic, decisions, creativity, ethics, writing, and strategy.
 - [superseo-skills](https://github.com/inhouseseo/superseo-skills) - SEO skill collection for audits, briefs, article writing, E-E-A-T, topic clusters, and link building.
 - [toprank](https://github.com/nowork-studio/toprank) - SEO and Google Ads skills for audits, metadata, schema, bids, and CMS fixes.
-
+- [kc_ai_skills](https://github.com/KerberosClaw/kc_ai_skills) - A Traditional Chinese-first collection of 22 reusable agent skills with bilingual documentation for Claude Code and Codex, including engineering-discipline workflows for requirements grilling, reproducible debugging, ADRs, and spec-driven delivery.
 
 ## 🤝 Contribution
 


### PR DESCRIPTION
Adds kc_ai_skills to the Collections section.

- 22 reusable agent skills (MIT), Traditional Chinese-first with bilingual (zh-TW / EN) README
- Follows the Claude Code skill convention; also usable from Codex CLI
- Includes engineering-discipline workflows: requirements grilling, reproducible debugging (red-capable repro before any hypothesis), lightweight ADRs, and spec-driven delivery