### PR TITLE
Add goose-skills to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@
 - [skills-for-humanity](https://github.com/human-avatar/skills-for-humanity) - Structured reasoning methodology skills for logic, decisions, creativity, ethics, writing, and strategy.
 - [superseo-skills](https://github.com/inhouseseo/superseo-skills) - SEO skill collection for audits, briefs, article writing, E-E-A-T, topic clusters, and link building.
 - [toprank](https://github.com/nowork-studio/toprank) - SEO and Google Ads skills for audits, metadata, schema, bids, and CMS fixes.
+- [goose-skills](https://github.com/gooseworks-ai/goose-skills) - 125 growth and GTM skills for ads, content, lead generation, outreach, competitive intel, monitoring, research, and SEO across Claude Code, Codex, and Cursor.
 
 
 ## 🤝 Contribution


### PR DESCRIPTION
Adds [goose-skills](https://github.com/gooseworks-ai/goose-skills) to the end of the **Collections** section.

Open-source (MIT) library of 125 growth/GTM skills — ads, content, lead generation, outreach, competitive intelligence, monitoring, research, and SEO — for Claude Code, Codex, and Cursor. 1,000+ stars, installable via CLI, each skill ships a SKILL.md with a metadata contract.

— Himanshu Bamoria, co-founder @ [GooseWorks](https://gooseworks.ai)

🤖 Generated with [Claude Code](https://claude.com/claude-code)