### PR TITLE
Add ambient-claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@
 - [pua](https://github.com/tanweai/pua) - Corporate motivation skill that pushes AI agents to exhaust options before giving up.
 - [sequenzy-email-marketing](https://clawhub.ai/polnikale/sequenzy-email-marketing) - Operate Sequenzy email marketing workflows for subscribers, campaigns, sequences, and templates.
 - [TweetClaw](https://github.com/Xquik-dev/tweetclaw) - X/Twitter automation skill for search, posting, follower export, monitors, webhooks, and giveaways.
+- [ambient-claude](https://github.com/chriswangcq/ambient-claude) - Claude Code, but it texts you first: a tiny zero-dep skill that connects your live session to Telegram/WeChat/Discord and lets it message you proactively.
 
 ## 📰 Articles & Blog Posts
 


### PR DESCRIPTION
Adds [ambient-claude](https://github.com/chriswangcq/ambient-claude) to Utility & Automation — a tiny zero-dependency Claude Code skill that connects a live session to Telegram, WeChat, or Discord so Claude can message you proactively, reusing your existing subscription with no extra API key.

I built it and use it daily as my own ambient assistant; MIT licensed, standard SKILL.md format. Entry follows the existing list style.