### PR TITLE
Add character-card-skills (roleplay character card authoring)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [avoid-ai-writing](https://github.com/conorbronsdon/avoid-ai-writing) - Audits and rewrites content to remove 21 categories of AI writing patterns with a 43-entry replacement table and two-pass detection.
+- [character-card-skills](https://github.com/foreverse-app/character-card-skills) - Roleplay character card authoring: 47 genre playbooks, a rule-based AI-flavor detector with public gold regression, chat-quality triage with per-model symptom profiles; 15 original cards ship as SillyTavern-ready v2 JSON / v3 PNG.
 - [naming](https://github.com/glacierphonk/naming) - Metaphor-driven naming for products, SaaS, brands, bots, and open source projects. Structured process that produces memorable, meaningful names.
 - [ru-text](https://github.com/talkstream/ru-text) - Russian text quality: ~1,040 rules for typography, info-style, editorial, UX writing, business correspondence
 - [md2wechat](https://github.com/geekjourneyx/md2wechat-skill) - Convert Markdown into WeChat Official Account drafts with preview, image, and cover handling.


### PR DESCRIPTION
Adds **character-card-skills** to Writing & Research (next to avoid-ai-writing, which it complements: that skill removes AI patterns from general prose, this one is a full authoring + detection pipeline for roleplay character cards).

Contents: two SKILL.md-convention skills — `character-card-author` (four-axis positioning, 47 genre playbooks, five opening-message paradigms, prose discipline with hard sentence-pattern quotas) and `chat-quality-doctor` (symptom-to-fix triage, 8 per-model RP profiles) — plus 15 original cards (card.md + chara_card_v2 JSON + v3 PNG each), the detector's gold regression set, and a zero-dependency converter. CI re-scores every card per commit.

Tested in Claude Code, Cursor, Codex. Code MIT, content CC BY 4.0. Disclosure: we build Foreverse; the repo is standalone.
