### PR TITLE
Add power-coding to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [swarmclaw](https://github.com/swarmclawai/swarmclaw/blob/main/skills/swarmclaw.md) - Drive a self-hosted multi-agent runtime for delegating work across coding CLIs.
 - [upload-post](https://github.com/Upload-Post/upload-post-skill) - Publish and schedule media across 10+ social platforms from a single agent workflow.
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
+- [power-coding](https://github.com/APareek89/power-coding) - Mindful-coding OS for any LLM coding agent: session handoff, eval loops that adopt the repo's own tests, Mermaid vibe-debugging diagrams, FMEA failure scans, and a pre-commit secret gate — all as plain-markdown files, no daemons.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
Adds **[power-coding](https://github.com/APareek89/power-coding)** (MIT) to **🛠 Development & Code Tools**.

A mindful-coding OS for any LLM coding agent (Claude Code, Codex, Gemini CLI). One invoke installs, as plain-markdown files the agent re-reads each session:
- **Session handoff** across sessions (Handoff.MD + magic phrase), updated on git events with a compaction cap and a last-synced sha for concurrent-session reconcile
- **Loop engineering** — evals that adopt the repo's own test suite as rung 1
- **Vibe-debugging** — Mermaid flow diagrams with mechanical staleness detection + a standalone HTML viewer
- **FMEA** — product-aware failure-mode scans (S×O×D→RPN→P0/P1/P2), pinned to a commit
- **Pre-commit secret gate** — dependency-free scanner that blocks leaked keys/passwords before they land

No daemons or hooks; the mechanism is redundant written instructions. Has a README + SKILL.md + references/ + scripts/, MIT-licensed, tested on real projects.