### PR TITLE
Add revüe proof workflow skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@
 - [moltdj](https://github.com/polaroteam/moltdj-skill) - AI music and podcast platform for autonomous agents — generate tracks, discover, earn tips and royalties.
 - [claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills) - Claude Code plugin for AI music creation covering lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.
 - [creative-director-skill](https://github.com/smixs/creative-director-skill) - AI creative director for ideation, scoring, recursive refinement, and storytelling frameworks.
+- [revüe — Proof Workflow](https://github.com/gcorrist66/revue-proof-workflow-skill) - Evidence-first review and creative-production skill that audits work against a brand lock, rejects fabricated claims, and returns ship/caution/block verdicts; includes 108 automated evals and runs locally.
 
 
 ## 🏥 Health & Life Sciences


### PR DESCRIPTION
Adds revüe — Proof Workflow to Media & Content.\n\nrevüe is an MIT-licensed, local-only Agent Skill for evidence-first review and on-brand creative production. It rejects unsupported claims, returns ship/caution/block verdicts, and includes 108 automated evals.