### PR TITLE
Add hotclip — local AI video clipping (long video → vertical shorts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@
 - [moltdj](https://github.com/polaroteam/moltdj-skill) - AI music and podcast platform for autonomous agents — generate tracks, discover, earn tips and royalties.
 - [claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills) - Claude Code plugin for AI music creation covering lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.
 - [creative-director-skill](https://github.com/smixs/creative-director-skill) - AI creative director for ideation, scoring, recursive refinement, and storytelling frameworks.
+- [hotclip](https://github.com/xixihhhh/hotclip) - Turn long videos and livestream VODs into vertical shorts 100% locally — on-device transcription, LLM highlight detection, 9:16 reframe with karaoke captions, and per-clip render QA with self-repair; bundles an Agent Skill, headless CLI, and local MCP server.
 
 
 ## 🏥 Health & Life Sciences


### PR DESCRIPTION
Adds **[hotclip](https://github.com/xixihhhh/hotclip)** to 🎬 Media & Content.

Free, open-source (AGPL-3.0) local AI clipping: drop in a long video or livestream VOD and get publish-ready 9:16 shorts — on-device word-level transcription, LLM highlight detection with an audiovisual evidence chain, frame-accurate cutting, face-tracked reframe, karaoke captions, and a per-clip render-QA report with a self-repair loop. Footage never leaves the machine.

Claude Code drives the same pipeline as the desktop app via the bundled Agent Skill ([skills/hotclip/SKILL.md](https://github.com/xixihhhh/hotclip/blob/main/skills/hotclip/SKILL.md)), a headless CLI, and a local stdio MCP server.