### PR TITLE
feat: add sparda-skills (Proof-Carrying Code for Agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@
 - [VibeSec-Skill](https://github.com/BehiSecc/VibeSec-Skill) - VibeSec helps Claude write secure code and prevent common vulnerabilities.
 - [defense-in-depth](https://github.com/obra/superpowers/blob/main/skills/defense-in-depth) - Implement multi-layered testing and security best practices.
 - [ffuf_claude_skill](https://github.com/jthack/ffuf_claude_skill) - Integrate Claude with FFUF (fuzzing) and analyze results for vulnerabilities.
+- [sparda-skills](https://github.com/zyx77550/sparda-skills) - Connects AI coding agents to the SPARDA Security Gate. Validates agent edits against invariants before applying them.
 - [owasp-security](https://github.com/agamm/claude-code-owasp) - OWASP Top 10:2025, ASVS 5.0, and Agentic AI security (2026) with code review checklists, secure patterns, and language-specific quirks for 20+ languages.
 - [systematic-debugging](https://github.com/obra/superpowers/blob/main/skills/systematic-debugging) - Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes
 - [Trail of Bits Security Skills](https://github.com/trailofbits/skills) - Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and fix verification.


### PR DESCRIPTION
Adds sparda-skills, a skill that connects AI coding agents to the SPARDA Security Gate to validate agent edits against runtime invariants before applying them.