### PR TITLE
Add ai-science-toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@
 - [skills-for-humanity](https://github.com/human-avatar/skills-for-humanity) - Structured reasoning methodology skills for logic, decisions, creativity, ethics, writing, and strategy.
 - [superseo-skills](https://github.com/inhouseseo/superseo-skills) - SEO skill collection for audits, briefs, article writing, E-E-A-T, topic clusters, and link building.
 - [toprank](https://github.com/nowork-studio/toprank) - SEO and Google Ads skills for audits, metadata, schema, bids, and CMS fixes.
+- [ai-science-toolkit](https://github.com/dgilford/ai-science-toolkit) - 18 Claude Code skills + 4 domain-expert reviewer agents (climate attribution, statistics, meteorology, science communication) for scientific research.
 
 
 ## 🤝 Contribution


### PR DESCRIPTION
Adds ai-science-toolkit — a bundle of Claude Code skills and domain-expert reviewer subagents for scientific research (climate attribution, statistics, meteorology, science communication), installable as a plugin. MIT-licensed, v1.0.0 with a Zenodo DOI.