### PR TITLE
Add agent37-skills-collection to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@
 - [skills-for-humanity](https://github.com/human-avatar/skills-for-humanity) - Structured reasoning methodology skills for logic, decisions, creativity, ethics, writing, and strategy.
 - [superseo-skills](https://github.com/inhouseseo/superseo-skills) - SEO skill collection for audits, briefs, article writing, E-E-A-T, topic clusters, and link building.
 - [toprank](https://github.com/nowork-studio/toprank) - SEO and Google Ads skills for audits, metadata, schema, bids, and CMS fixes.
+- [agent37-skills-collection](https://github.com/agent37-platform/agent37-skills-collection) - Claude Code plugin marketplace with three plugins: yc-advisor (YC startup advice from 434 curated resources), local-review (uncommitted-diff review), and generate-prompt-request (session-to-PR one-pagers).
 
 
 ## 🤝 Contribution


### PR DESCRIPTION
Adds agent37-skills-collection to the Collections section. It is a Claude Code plugin marketplace containing three plugins: yc-advisor (YC startup advice drawn from 434 curated resources), local-review (review of uncommitted local diffs), and generate-prompt-request (one-page session summaries for pull requests). The entry follows the existing list format and is appended at the end of the section.