### PR TITLE
Add claude-code-eyes to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [swarmclaw](https://github.com/swarmclawai/swarmclaw/blob/main/skills/swarmclaw.md) - Drive a self-hosted multi-agent runtime for delegating work across coding CLIs.
 - [upload-post](https://github.com/Upload-Post/upload-post-skill) - Publish and schedule media across 10+ social platforms from a single agent workflow.
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
+- [claude-code-eyes](https://github.com/fcavalcantirj/claude-code-eyes) - Camera-vision skill that lets Claude see real hardware, displays, and wiring through a camera to visually verify a rendered panel or check wiring before power-on.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
Adds [claude-code-eyes](https://github.com/fcavalcantirj/claude-code-eyes) under Development & Code Tools. Open-source (MIT) Claude Code skill: Claude grabs a frame from a snapshot camera (Android IP Webcam, Raspberry Pi camera-streamer, or any snapshot URL) and reads it — to visually verify a rendered display/panel or check wiring and voltage rails before power-on, i.e. catch output no unit test can see. Documented (README + one-command setup), tested under bash 3.2.