### PR TITLE
Add Banuba Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [swarmclaw](https://github.com/swarmclawai/swarmclaw/blob/main/skills/swarmclaw.md) - Drive a self-hosted multi-agent runtime for delegating work across coding CLIs.
 - [upload-post](https://github.com/Upload-Post/upload-post-skill) - Publish and schedule media across 10+ social platforms from a single agent workflow.
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
+- [Banuba Agent Skills](https://github.com/Banuba/ai-skills) - Banuba Agent Skills enable creating apps with Banuba SDKs by using Claude Code, Codex, and Qwen Code.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
Banuba Agent Skills let users create apps with Banuba SDKs (Face AR, Video Editor & Photo Editor) with an AI coding assistant: Claude Code, Codex, and Qwen. 

The skills contain the following components:

Documentation lookup skills are local-first and can answer from bundled docs. Builder skills may access the network to fetch versioned LLM docs, clone official samples, and install platform dependencies.
Guided code generation - a step-by-step walkthrough and explanation of SDK implementation
Autonomous scaffolding - a builder agent that creates complete Face AR, Video Editor, or Photo Editor projects from scratch