### PR TITLE
Add resume-studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@
 - [ru-text](https://github.com/talkstream/ru-text) - Russian text quality: ~1,040 rules for typography, info-style, editorial, UX writing, business correspondence
 - [md2wechat](https://github.com/geekjourneyx/md2wechat-skill) - Convert Markdown into WeChat Official Account drafts with preview, image, and cover handling.
 - [buyer-eval](https://github.com/salespeak-ai/buyer-eval-skill) - Evaluate B2B vendors by interrogating agents, checking claims, and scoring weighted criteria.
+- [resume-studio](https://github.com/Sidgit11/resume-studio) - Builds a permanent memory of your career and tailors an ATS-safe, evidence-backed resume for every job. No fabricated claims, learns your style permanently.
 
 
 ## 📘 Learning & Knowledge  


### PR DESCRIPTION
Adds resume-studio under Writing & Research. The skill builds a permanent memory of your career and tailors an ATS-safe, evidence-backed resume for every job, without fabricating claims. Entry follows your contribution format: a single-line `- [name](url) - Description.` bullet appended to the existing Writing & Research category.