### PR TITLE
Add de-slop to Writing & Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@
 - [ru-text](https://github.com/talkstream/ru-text) - Russian text quality: ~1,040 rules for typography, info-style, editorial, UX writing, business correspondence
 - [md2wechat](https://github.com/geekjourneyx/md2wechat-skill) - Convert Markdown into WeChat Official Account drafts with preview, image, and cover handling.
 - [buyer-eval](https://github.com/salespeak-ai/buyer-eval-skill) - Evaluate B2B vendors by interrogating agents, checking claims, and scoring weighted criteria.
+- [de-slop](https://github.com/isatimur/de-slop) - Removes "AI slop" (hedging, listicle stems, filler) without faking a voice: subtractive rewrites self-scored against a rubric, flags hollow spans instead of fabricating claims. Zero-dependency, MIT.
 
 
 ## 📘 Learning & Knowledge  


### PR DESCRIPTION
Adds [de-slop](https://github.com/isatimur/de-slop) to the Writing & Research section.

Removes AI-flavored prose patterns (empty hedging, listicle stems, filler transitions) via subtractive rewrites, self-scores against an embedded rubric, and flags hollow spans instead of inventing claims to fill them. MIT, zero-dependency (stdlib-only Python 3.9–3.13), works in Claude Code / Cursor / Copilot / Codex / Gemini / Windsurf from one source.

Distinct from the existing avoid-ai-writing entry: de-slop's method is subtractive and self-scoring (detect → judge against a rubric → rewrite only what's rewordable → flag what it can't fix, never fabricate) rather than a fixed replacement-table pass — the two can be read as complementary approaches to the same problem.