### PR TITLE
Add UIZZE UI research skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [swarmclaw](https://github.com/swarmclawai/swarmclaw/blob/main/skills/swarmclaw.md) - Drive a self-hosted multi-agent runtime for delegating work across coding CLIs.
 - [upload-post](https://github.com/Upload-Post/upload-post-skill) - Publish and schedule media across 10+ social platforms from a single agent workflow.
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
+- [uizze-ui-research](https://github.com/aislon/uizze-mcp/tree/main/skills/uizze-ui-research) - Grounds Claude Code UI work in 800,000+ real web and iOS screens, then applies a product-specific design contract and finish-gate review with [UIZZE](https://uizze.com).
 
 
 ## 📊 Data & Analysis

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@
 - [swarmclaw](https://github.com/swarmclawai/swarmclaw/blob/main/skills/swarmclaw.md) - Drive a self-hosted multi-agent runtime for delegating work across coding CLIs.
 - [upload-post](https://github.com/Upload-Post/upload-post-skill) - Publish and schedule media across 10+ social platforms from a single agent workflow.
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
-- [uizze-ui-research](https://github.com/aislon/uizze-mcp/tree/main/skills/uizze-ui-research) - Grounds Claude Code UI work in 800,000+ real web and iOS screens, then applies a product-specific design contract and finish-gate review with [UIZZE](https://uizze.com).
+- [uizze-ui-research](https://github.com/uizze/uizze-mcp/tree/main/skills/uizze-ui-research) - Grounds Claude Code UI work in 800,000+ real web and iOS screens, then applies a product-specific design contract and finish-gate review with [UIZZE](https://uizze.com).
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
## Summary

Add the source-backed UIZZE UI research skill to Development & Code Tools. The entry links the skill in the public canonical repository and the product at plain https://uizze.com.

## Fit

The skill is a free Claude Code-compatible workflow for UI research, a product-specific design contract, and a finish-gate review before shipping. It also supports Codex, Cursor, Copilot, and other coding agents.

## Validation

- searched the README, existing pull requests, and issues for duplicates
- confirmed both public links return HTTP 200
- verified every claim against the source SKILL.md
- ran git diff --check

No pricing or tracking parameters are included.