### PR TITLE
Add shelf-skills to Learning & Knowledge

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [llm-wiki](https://github.com/praneybehl/llm-wiki-plugin) - Build and maintain an LLM-curated personal knowledge base with sharded indexes and search.
 - [swarmvault](https://github.com/swarmclawai/swarmvault) - Compile docs, research, and code into a local markdown wiki, knowledge graph, and hybrid search index.
+- [shelf-skills](https://github.com/Ranveersingh1113/shelf-skills) - Turn saved links into a searchable markdown library and surface the right one mid-task. Notes are indexed by the problem they solve, and recall says nothing matches rather than padding weak results.
 
 
 


### PR DESCRIPTION
Adds `shelf-skills` to **Learning & Knowledge** — it sits naturally alongside `llm-wiki`, `karpathy-llm-wiki` and `swarmvault`, but solves the opposite half of the problem: not building a knowledge base, but *getting things back out of one at the moment they matter*.

**The problem:** you save useful tools and articles from newsletters, and they pile up unread and unsearchable. Months later a real need comes up and you have no idea the relevant link is already sitting in your notes.

**Two skills:**
- `shelf-save` — batch-processes a file of URLs into one markdown note per tool. Fetches each page, dedupes against an append-only archive, rebuilds a category index. Pages that can't be fetched fall back to search and get flagged `confidence: low`; total failures stay in the inbox rather than becoming a hallucinated note.
- `shelf-find` — read-only. Searches those notes automatically whenever you're choosing a tool, without needing to be called by name.

Notes are indexed on a `problem_solved` field written as *the user's problem*, not the product's pitch — that's the shape of the question you'll actually ask later.

**The part I'd point at:** recall refuses to stretch. If nothing genuinely fits, it says so and offers a clearly-separated web search instead of returning five weak matches. A library you stop trusting is worse than no library.

Plain markdown on disk — no plugin, no MCP server, no database, no API key. Follows the [Agent Skills](https://agentskills.io) core spec with no agent-specific extensions, so it runs on any skills-compatible agent. MIT licensed.