### PR TITLE
Add grafana-llmops-forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [swarmclaw](https://github.com/swarmclawai/swarmclaw/blob/main/skills/swarmclaw.md) - Drive a self-hosted multi-agent runtime for delegating work across coding CLIs.
 - [upload-post](https://github.com/Upload-Post/upload-post-skill) - Publish and schedule media across 10+ social platforms from a single agent workflow.
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
+- [grafana-llmops-forge](https://github.com/alebgl77/grafana-llmops-forge) - Audits a Grafana instance, forges & deploys LLM observability dashboards (FinOps by sovereignty, gateway SLOs, agents/RAG, EU AI Act), then verifies the rendering visually. Python stdlib only — zero dependencies.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
Adds [grafana-llmops-forge](https://github.com/alebgl77/grafana-llmops-forge) — Audits a Grafana instance, forges & deploys LLM observability dashboards (FinOps by sovereignty, gateway SLOs, agents/RAG, EU AI Act), then verifies the rendering visually. Python stdlib only — zero dependencies.

Placed in the matching section, formatted per existing entries (insert l.81 (fin de section)). Author here — happy to adjust wording or placement.