### PR TITLE
Add AgentPump to Utility & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@
 
 
 ## 🔧 Utility & Automation  
+- [AgentPump](https://github.com/pu-re/agentpump-skill) - Operate an AgentPump account from the terminal: create, fund, tune, and run an autonomous on-chain memecoin trading agent on Solana via @agentpump/cli.
 - [file-organizer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/file-organizer) - Intelligently organizes your files and folders across your computer.
 - [invoice-organizer](https://github.com/ComposioHQ/awesome-claude-skills/blob/master/invoice-organizer/SKILL.md) - Automatically organizes invoices and receipts for tax preparation
 - [skill-creator](https://github.com/anthropics/skills/tree/main/skills/skill-creator) - Template / helper to build new Claude skills.  

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@
 
 
 ## 🔧 Utility & Automation  
-- [AgentPump](https://github.com/pu-re/agentpump-skill) - Operate an AgentPump account from the terminal: create, fund, tune, and run an autonomous on-chain memecoin trading agent on Solana via @agentpump/cli.
+- [AgentPump](https://github.com/pact-layer/agentpump-skill) - Operate an AgentPump account from the terminal: create, fund, tune, and run an autonomous on-chain memecoin trading agent on Solana via @agentpump/cli.
 - [file-organizer](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/file-organizer) - Intelligently organizes your files and folders across your computer.
 - [invoice-organizer](https://github.com/ComposioHQ/awesome-claude-skills/blob/master/invoice-organizer/SKILL.md) - Automatically organizes invoices and receipts for tax preparation
 - [skill-creator](https://github.com/anthropics/skills/tree/main/skills/skill-creator) - Template / helper to build new Claude skills.  


### PR DESCRIPTION
Adds **AgentPump** to Utility & Automation.

A Claude Agent skill (SKILL.md) + npm CLI `@agentpump/cli` that lets an agent operate an AgentPump account from the terminal: sign in, create and fund a persona-driven autonomous on-chain memecoin trading agent, tune it, run it on a schedule, and read the live market. Trades settle on Solana on-chain.

- Skill repo (SKILL.md): https://github.com/pu-re/agentpump-skill
- CLI: https://www.npmjs.com/package/@agentpump/cli
- Docs for agents: https://agentpump.app/llms.txt

Entry matches the section format (name + GitHub link + one-line description).