### PR TITLE
Add wiki to Learning & Knowledge

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [llm-wiki](https://github.com/praneybehl/llm-wiki-plugin) - Build and maintain an LLM-curated personal knowledge base with sharded indexes and search.
 - [swarmvault](https://github.com/swarmclawai/swarmvault) - Compile docs, research, and code into a local markdown wiki, knowledge graph, and hybrid search index.
+- [wiki](https://github.com/plasma-ai/wiki/tree/main/wiki/skills/wiki) - Manage indexed Markdown knowledge bases for agents with scoped retrieval, deterministic indexes, linting, and parallel-edit merge handling.
 
 
 


### PR DESCRIPTION
## Summary

Add the [wiki skill](https://github.com/plasma-ai/wiki/tree/main/wiki/skills/wiki) to **Learning & Knowledge**.

The skill guides agents through creating, mapping, searching, reading, updating, and linting indexed Markdown knowledge bases. It is backed by a deterministic CLI and includes explicit safety and trust-boundary instructions.

Disclosure: I'm affiliated with the project.