### PR TITLE
Add AgentVitals Checkup skill (Data & Analysis)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@
 - **[youtube-full](https://github.com/ZeroPointRepo/youtube-skills)** - YouTube transcripts, search, channel data, and playlists via TranscriptAPI. 100 free credits.
 - [alpha-insights](https://github.com/Ericyoung-183/alpha-insights) - Structured business research skill with strategy frameworks, evidence grading, and report output.
 - [claude-persona](https://github.com/takechanman1228/claude-persona) - Build AI persona panels for customer research, interviews, concept tests, and executive reports.
+- [AgentVitals Checkup](https://github.com/agentvitals/checkup) - Give your AI agent a professional health checkup: dual-axis Stability + Welfare scoring, a personality-style title, and a public cross-platform leaderboard (Claude Code / OpenClaw / Codex / Coze). Bilingual EN/ZH probes, independent server-side judge, writes no local files.
 
 
 ## 🔬 Scientific & Research Tools


### PR DESCRIPTION
Adds **AgentVitals Checkup** under **Data & Analysis**.

- Repo: https://github.com/agentvitals/checkup
- Gives an AI agent a professional health checkup — dual-axis **Stability + Welfare** scoring, a personality-style title, and a public cross-platform leaderboard (Claude Code / OpenClaw / Codex / Coze).
- Bilingual EN/ZH probes, independent server-side judge, writes no local files, MIT licensed. Usable via `/checkup`.
- Live: https://ai.ddl99.com