### PR TITLE
Add MarchTalk/ai-content-skills to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@
 - [skills-for-humanity](https://github.com/human-avatar/skills-for-humanity) - Structured reasoning methodology skills for logic, decisions, creativity, ethics, writing, and strategy.
 - [superseo-skills](https://github.com/inhouseseo/superseo-skills) - SEO skill collection for audits, briefs, article writing, E-E-A-T, topic clusters, and link building.
 - [toprank](https://github.com/nowork-studio/toprank) - SEO and Google Ads skills for audits, metadata, schema, bids, and CMS fixes.
+- [MarchTalk/ai-content-skills](https://github.com/MarchTalk/ai-content-skills) - 11 Chinese-language content-creation skills with quality gates: real-material research (forces web-verified facts before drafting), AI-writing-pattern detection, quality gate, positioning, topic strategy, and platform (Douyin/Xiaohongshu) adaptation.
 
 
 ## 🤝 Contribution


### PR DESCRIPTION
Adds a Chinese-language content-creation skill collection: 11 SKILL.md files covering real-material research (forces web-verified facts before drafting instead of generic filler), a final quality gate (AI-writing-pattern detection, banned-phrase checks, per-content-type checklists), positioning, topic strategy, and Douyin/Xiaohongshu platform adaptation. MIT licensed.

Repo: https://github.com/MarchTalk/ai-content-skills