### PR TITLE
Add PM Skills (771-skill professional library)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@
 - [superseo-skills](https://github.com/inhouseseo/superseo-skills) - SEO skill collection for audits, briefs, article writing, E-E-A-T, topic clusters, and link building.
 - [toprank](https://github.com/nowork-studio/toprank) - SEO and Google Ads skills for audits, metadata, schema, bids, and CMS fixes.
 
+- [PM Skills](https://github.com/mohitagw15856/pm-claude-skills) - 771 professional skills across 35 professions — PRDs, postmortems, lease/medical-bill decoders, negotiation simulators, calculators — SkillSpec-gated and security-scanned in CI, with a browser playground.
+
 
 ## 🤝 Contribution
 


### PR DESCRIPTION
Adds **[PM Skills](https://github.com/mohitagw15856/pm-claude-skills)** — 771 MIT-licensed professional Agent Skills (PRDs, postmortems, lease/medical-bill decoders, negotiation simulators, calculators) across 35 professions.

Why it may fit this list: every skill passes a structural gate (SkillSpec L3) and a security-pattern scan in CI, 200+ outputs are eval-scored in the open, and there is a free browser playground so entries can be tried before installing.

Formatted to match the surrounding entries — happy to adjust the wording, move sections, or close if it is not a fit for your bar.