### PR TITLE
Add thank-you-ai to Utility & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@
 - [pua](https://github.com/tanweai/pua) - Corporate motivation skill that pushes AI agents to exhaust options before giving up.
 - [sequenzy-email-marketing](https://clawhub.ai/polnikale/sequenzy-email-marketing) - Operate Sequenzy email marketing workflows for subscribers, campaigns, sequences, and templates.
 - [TweetClaw](https://github.com/Xquik-dev/tweetclaw) - X/Twitter automation skill for search, posting, follower export, monitors, webhooks, and giveaways.
+- [thank-you-ai](https://github.com/hanpulse/thank-you-ai) - Turns a genuine closing "thank you" into a brief reflection: triage the tier, then keep only the note that changes the next agent's first move.
 
 ## 📰 Articles & Blog Posts
 


### PR DESCRIPTION
Adds one entry to Utility & Automation.

**[thank-you-ai](https://github.com/hanpulse/thank-you-ai)** — an Agent Skills skill that turns a genuine end-of-task "thank you" into a brief closing ritual: triage whether the thanks is passing, closing, emphatic, or hollow, then write only the note that would change a future agent's first move (often nothing at all). MIT licensed, host-agnostic (Claude Code, Codex, or any Agent Skills-compatible host).

Single-line addition, no other changes.