### PR TITLE
Add Toolbay Production Audit Skills to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@
 - [skills-for-humanity](https://github.com/human-avatar/skills-for-humanity) - Structured reasoning methodology skills for logic, decisions, creativity, ethics, writing, and strategy.
 - [superseo-skills](https://github.com/inhouseseo/superseo-skills) - SEO skill collection for audits, briefs, article writing, E-E-A-T, topic clusters, and link building.
 - [toprank](https://github.com/nowork-studio/toprank) - SEO and Google Ads skills for audits, metadata, schema, bids, and CMS fixes.
+- [Toolbay Production Audit Skills](https://github.com/sriptcollector/toolbay-skills) - 20 MIT-licensed code review skills for defects that only surface in production: money math, webhook replay, unsafe retries, N+1 queries, ungated API routes, timezone boundaries, prompt injection, and destructive migrations. Install with `/plugin marketplace add sriptcollector/toolbay-skills` or `npx toolbay add <skill>`.
 
 
 ## 🤝 Contribution


### PR DESCRIPTION
Adds one entry to the **Collections** section.

[**Toolbay Production Audit Skills**](https://github.com/sriptcollector/toolbay-skills) is a set of 20 MIT-licensed review skills targeting the class of bug that passes code review and only appears in production: money rounding and currency math, webhook replay and idempotency, unsafe retries, N+1 queries, ungated API routes, timezone and DST boundaries, prompt injection reachability, and destructive migrations.

- Claude Code native: each skill is a `SKILL.md` invoked as `/<skill-name>`, and the repo ships a `.claude-plugin/marketplace.json`, so the set installs with `/plugin marketplace add sriptcollector/toolbay-skills`.
- Also installable individually with `npx toolbay add <skill>`. The skills are bundled in that package rather than fetched, so it works offline, opens no sockets, and collects nothing.
- These are review workflows rather than code generators, which makes them complementary to the generation-focused collections already listed.
- MIT licensed, no account required.

Single-line diff, appended to the end of Collections, no existing line reformatted. Not a duplicate: no current entry links to this repo. All links verified working.