### PR TITLE
Add DealMachine skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@
 - **[youtube-full](https://github.com/ZeroPointRepo/youtube-skills)** - YouTube transcripts, search, channel data, and playlists via TranscriptAPI. 100 free credits.
 - [alpha-insights](https://github.com/Ericyoung-183/alpha-insights) - Structured business research skill with strategy frameworks, evidence grading, and report output.
 - [claude-persona](https://github.com/takechanman1228/claude-persona) - Build AI persona panels for customer research, interviews, concept tests, and executive reports.
+- [dealmachine](https://github.com/DealMachine/dealmachine-cli/tree/master/skills/dealmachine) - Official DealMachine skill for US property, owner, people, and company intelligence through hosted MCP tools or the `dm` CLI, with credit-aware search, enrichment, comparable sales, and targeted exports.
 
 
 ## 🔬 Scientific & Research Tools

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@
 - **[youtube-full](https://github.com/ZeroPointRepo/youtube-skills)** - YouTube transcripts, search, channel data, and playlists via TranscriptAPI. 100 free credits.
 - [alpha-insights](https://github.com/Ericyoung-183/alpha-insights) - Structured business research skill with strategy frameworks, evidence grading, and report output.
 - [claude-persona](https://github.com/takechanman1228/claude-persona) - Build AI persona panels for customer research, interviews, concept tests, and executive reports.
-- [dealmachine](https://github.com/DealMachine/dealmachine-cli/tree/master/skills/dealmachine) - Official DealMachine skill for US property, owner, people, and company intelligence through hosted MCP tools or the `dm` CLI, with credit-aware search, enrichment, comparable sales, and targeted exports.
+- [dealmachine](https://github.com/DealMachine/dealmachine-cli/tree/master/skills/dealmachine) - Official DealMachine skill for US property, owner, and people intelligence through hosted MCP tools or the `dm` CLI, with credit-aware search, enrichment, comparable sales, and targeted exports.
 
 
 ## 🔬 Scientific & Research Tools


### PR DESCRIPTION
Adds the official DealMachine skill to Data & Analysis.

The skill gives Claude an MCP-first, CLI-fallback workflow for US property, owner, and people intelligence. It covers credit-aware discovery, search, enrichment, comparable sales, and targeted exports.

- Skill: https://github.com/DealMachine/dealmachine-cli/tree/master/skills/dealmachine
- Hosted MCP: https://mcp.dealmachine.com
- Docs: https://api.docs.dealmachine.com