### PR TITLE
Add plan-diagram skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [swarmclaw](https://github.com/swarmclawai/swarmclaw/blob/main/skills/swarmclaw.md) - Drive a self-hosted multi-agent runtime for delegating work across coding CLIs.
 - [upload-post](https://github.com/Upload-Post/upload-post-skill) - Publish and schedule media across 10+ social platforms from a single agent workflow.
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
+- [plan-diagram](https://github.com/ANC1024GO/claude-skill-plan-diagram) - Turn any plan, flow, or architecture into a dark, hand-drawn (Excalidraw-style) HTML diagram — multilingual with automatic RTL, vertical flow or pan/zoom board layouts.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
Adds [plan-diagram](https://github.com/ANC1024GO/claude-skill-plan-diagram) to **Development & Code Tools**.

A Claude Code skill that turns any plan, flow, decision order, or architecture into a self-contained, dark hand-drawn (Excalidraw-style) HTML diagram. Two layouts (vertical FLOW / pan-zoom BOARD), writes the diagram in whatever language the plan is in (automatic RTL), no build step, ships a local structural validator. MIT licensed, installable via plugin marketplace or plain clone.