### PR TITLE
Add krosos-mcp to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@
 - **[youtube-full](https://github.com/ZeroPointRepo/youtube-skills)** - YouTube transcripts, search, channel data, and playlists via TranscriptAPI. 100 free credits.
 - [alpha-insights](https://github.com/Ericyoung-183/alpha-insights) - Structured business research skill with strategy frameworks, evidence grading, and report output.
 - [claude-persona](https://github.com/takechanman1228/claude-persona) - Build AI persona panels for customer research, interviews, concept tests, and executive reports.
-
+- [krosos-mcp](https://github.com/Krosos/krosos-mcp) - Personal accounting ledger for AI agents: net worth, holdings, transaction history, EU capital-gains tax estimates, and trade logging via scoped tokens.
 
 ## 🔬 Scientific & Research Tools
 - [claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills) - 125+ scientific skills for bioinformatics, cheminformatics, clinical research, and machine learning.


### PR DESCRIPTION
Adds [krosos-mcp](https://github.com/Krosos/krosos-mcp) to the Data & Analysis section.

The skill lets Claude operate a personal accounting ledger (Krosos): net worth, holdings, transaction history, EU capital-gains tax estimates, and trade logging. Auth is a scoped API token the user mints themselves (read-only or read/write). The repo also ships a remote MCP server for the same surface.

Disclosure: I'm the founder of Krosos.