### PR TITLE
Add wf-toolkit (Adobe Workfront skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@
 - [Product-Manager-Skills](https://github.com/deanpeters/Product-Manager-Skills) - Product management skill library covering discovery, prioritization, PRDs, roadmap planning, and SaaS metrics.
 - [product-manager-skills](https://github.com/Digidai/product-manager-skills) - Senior PM agent with 6 knowledge domains, 12 templates, and 30+ frameworks covering discovery, strategy, delivery, SaaS metrics, PM career coaching (IC to CPO), and AI product craft.
 - [cup](https://github.com/krodak/clickup-cli) - ClickUp CLI for AI agents and humans. 40+ commands for tasks, sprints, time tracking. Ships as a Claude Code plugin.
+- [wf-toolkit](https://github.com/Thousand-Cuts/wf-toolkit) - Adobe Workfront skills: text mode reporting, REST API, calculated custom fields, custom forms, business rules, permissions diagnostics, and reports, verified against live Workfront tenants.
 
 
 ## 🛡 Security & Web Testing


### PR DESCRIPTION
Adds wf-toolkit to Collaboration & Project Management: seven Adobe Workfront skills for Claude (text mode reporting, REST API, calculated custom fields, custom forms, business rules, permissions diagnostics, reports). Knowledge files verified against live Workfront tenants with dated findings. MIT licensed.