### PR TITLE
Add astro-skills to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@
 - [skills-for-humanity](https://github.com/human-avatar/skills-for-humanity) - Structured reasoning methodology skills for logic, decisions, creativity, ethics, writing, and strategy.
 - [superseo-skills](https://github.com/inhouseseo/superseo-skills) - SEO skill collection for audits, briefs, article writing, E-E-A-T, topic clusters, and link building.
 - [toprank](https://github.com/nowork-studio/toprank) - SEO and Google Ads skills for audits, metadata, schema, bids, and CMS fixes.
+- [astro-skills](https://github.com/iAstroUnicorn/astro-skills) - 7 original bilingual (zh/en) skills for agent reliability: guardrails (write safety, context overflow, anti-hallucination fact stitching), first-principles thinking, archiving, path migration, and cross-agent collaboration.
 
 
 ## 🤝 Contribution


### PR DESCRIPTION
Adds [astro-skills](https://github.com/iAstroUnicorn/astro-skills) to the Collections section.

**astro-skills** — 7 original bilingual (zh/en) skills for AI agent reliability, Apache 2.0, following the Agent Skills open standard:

- Guardrails: `kernel-security` / `context-guard` / `semantic-stitching-guard` (anti-hallucination fact-stitching checks)
- Thinking: `origin-thinking` (first-principles four-lens workflow)
- Productivity: `archive`, `safe-path-migration`
- Collaboration: `bifrost` (cross-agent discussion protocol with script)

Each skill ships with Chinese `SKILL.md` + English `SKILL.en.md`. Link verified.