### PR TITLE
Add claude-math to Writing & Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@
 - [ru-text](https://github.com/talkstream/ru-text) - Russian text quality: ~1,040 rules for typography, info-style, editorial, UX writing, business correspondence
 - [md2wechat](https://github.com/geekjourneyx/md2wechat-skill) - Convert Markdown into WeChat Official Account drafts with preview, image, and cover handling.
 - [buyer-eval](https://github.com/salespeak-ai/buyer-eval-skill) - Evaluate B2B vendors by interrogating agents, checking claims, and scoring weighted criteria.
+- [claude-math](https://github.com/vladimirrott/claude-math) - Render mathematics as terminal-safe inline Unicode (∑, ≤, ℝ, x², matrices, set-builder) instead of LaTeX that terminals cannot display.
 
 
 ## 📘 Learning & Knowledge  


### PR DESCRIPTION
One line added to **✍️ Writing & Research**.

`claude-math` makes mathematical notation legible where it currently is not: a
terminal. Claude Code, Codex CLI and plain shells render neither `$...$` nor
`\frac{a}{b}`, so quantitative answers arrive as markup. The skill emits inline
Unicode instead, so the notation survives copy, paste and grep:

- `Q = { (s,r) : n_{s,r} ≥ 6 ∧ p⁰_{s,r} < 0.9 }` rather than a LaTeX block
- `|Q| / |T| = 5 238 / 31 000 ≈ 16.9 %`

Details:

- Repo: https://github.com/vladimirrott/claude-math
- Skill: `skills/math-unicode/SKILL.md`, plus an installer, docs and tests
- MIT, no telemetry, no network calls, nothing to sign up for
- Works in Claude Code and Codex CLI

Category note: I put it under Writing & Research next to `ru-text` and
`md2wechat`, since it is a typography and notation rule set. **Scientific &
Research Tools** is a reasonable alternative; say the word and I will move it.