### PR TITLE
Add octopus-skill (long-horizon agent skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 
 
 ## 🛠 Development & Code Tools
+- [octopus-skill](https://github.com/levi-qiao/octopus-skill) - Long-horizon agent skill: stop agent drift with a durable ledger, clean-context supervisor, and verified gates. Works on Claude Code, Cursor, Codex, and Grok. Markdown prompt library — not an orchestration framework.
 - [web-artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.


### PR DESCRIPTION
## Why

Long-horizon Claude Code / agent work often drifts: self-reported "done", lost early decisions after context compaction, no independent verifier.

**octopus-skill** is a curated Markdown prompt library (not a runtime) that wires executor + clean-context supervisor + optional scout through durable files (`ledger.md`, `directives.md`). Arms: `quest` (single goal) and `loop-graph` (gated multi-milestone). Hosts: Claude Code plugin, Cursor, Codex, Grok.

## Links

- Repo: https://github.com/levi-qiao/octopus-skill
- Install (Claude Code):
  ```
  /plugin marketplace add levi-qiao/octopus-skill
  /plugin install octopus@octopus-skill
  ```

## Checklist

- [x] Public GitHub repo with MIT license
- [x] Clear README with install + when to use / when not
- [x] Distinct from orchestration frameworks (Markdown skills only)
