### PR TITLE
Add feynman-technique to Learning & Knowledge

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [llm-wiki](https://github.com/praneybehl/llm-wiki-plugin) - Build and maintain an LLM-curated personal knowledge base with sharded indexes and search.
 - [swarmvault](https://github.com/swarmclawai/swarmvault) - Compile docs, research, and code into a local markdown wiki, knowledge graph, and hybrid search index.
+- [feynman-technique](https://github.com/guicortei/feynman-technique) - Explains mechanism first and names it last, on a ladder from layperson to specialist, with every term defined at first use and each analogy's limits stated. Inverts into a coach mode that makes you do the explaining.
 
 
 


### PR DESCRIPTION
One entry added to **📘 Learning & Knowledge**.

**[feynman-technique](https://github.com/guicortei/feynman-technique)** — makes an assistant explain the mechanism before naming it, on a ladder from layperson to specialist, with every term defined at first use and each analogy's limits stated. It also inverts: a coach mode where the model refuses to explain and makes you do it, pointing at one hole at a time.

It fits this section rather than Writing & Research because the subject is how something gets understood, not how it gets written.

- Instructions only — no scripts, no network calls, no file operations.
- Conforms to the [Agent Skills open standard](https://agentskills.io); install paths documented for Claude Code, claude.ai, ChatGPT, Codex CLI, Cursor, VS Code/Copilot and Gemini CLI.
- CI validates the frontmatter against the spec on every push.
- README available in ten languages.

On the name: the skill does not claim Feynman authored the four-step method — that came from later popularizers. `references/sources.md` separates the quotations that are verifiable from the ones commonly misattributed to him.