### PR TITLE
Add mail-muncher skill to Utility & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@
 - [pua](https://github.com/tanweai/pua) - Corporate motivation skill that pushes AI agents to exhaust options before giving up.
 - [sequenzy-email-marketing](https://clawhub.ai/polnikale/sequenzy-email-marketing) - Operate Sequenzy email marketing workflows for subscribers, campaigns, sequences, and templates.
 - [TweetClaw](https://github.com/Xquik-dev/tweetclaw) - X/Twitter automation skill for search, posting, follower export, monitors, webhooks, and giveaways.
+- [mail-muncher](https://github.com/craigjmidwinter/mail-muncher/tree/main/skills/mail-muncher) - Give an agent its own read-only mailbox. Sets up filter rules over any IMAP account or Gmail, archives matching mail to disk as .eml plus markdown, and wires up the MCP server that reads it back.
 
 ## 📰 Articles & Blog Posts
 


### PR DESCRIPTION
Adds the [mail-muncher](https://github.com/craigjmidwinter/mail-muncher/tree/main/skills/mail-muncher) skill to **Utility & Automation**.

The skill teaches Claude to give an agent its own read-only mailbox: it writes the config, sets up ordered filter rules over any IMAP account (Fastmail, iCloud, Proton Bridge, self-hosted) or the Gmail API, and wires up the bundled MCP server so the archived mail can be read back as tool calls.

It is more than a single `SKILL.md` — the skill ships four reference files it loads on demand:

- `references/setup.md` — every config key and flag, both provider paths
- `references/filters.md` — the rule language and how match order resolves
- `references/output.md` — the on-disk layout, `.eml` and markdown with YAML frontmatter
- `references/mcp.md` — the five MCP tools and how to wire the server into a client

Mail is never sent, deleted or modified: IMAP folders are opened with `EXAMINE` and bodies fetched with `BODY.PEEK[]`, and the Gmail path requests only the `gmail.readonly` scope.

MIT licensed. One item, added to the end of the category, links verified.