### PR TITLE
Add bullshit-detector to Writing & Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@
 - [ru-text](https://github.com/talkstream/ru-text) - Russian text quality: ~1,040 rules for typography, info-style, editorial, UX writing, business correspondence
 - [md2wechat](https://github.com/geekjourneyx/md2wechat-skill) - Convert Markdown into WeChat Official Account drafts with preview, image, and cover handling.
 - [buyer-eval](https://github.com/salespeak-ai/buyer-eval-skill) - Evaluate B2B vendors by interrogating agents, checking claims, and scoring weighted criteria.
+- [bullshit-detector](https://github.com/SerhiiKorniienko/bullshit-detector) - Extract every claim from a video, article, tweet or PDF, verify each against independent sources, get per-claim verdicts and a 0-10 BS score.
 
 
 ## 📘 Learning & Knowledge  


### PR DESCRIPTION
Adds [bullshit-detector](https://github.com/SerhiiKorniienko/bullshit-detector) under **✍️ Writing & Research**.

Extracts every discrete claim from a video, article, tweet or PDF, verifies each against independent sources via web search, and returns per-claim verdicts with a 0-10 BS score.

The distinguishing bit: sources are ranked into tiers with empirical and primary evidence on top, and it counts **independent origins rather than URLs**, so ten reprints of a single press release don't count as ten confirmations.

- Five complete reports in [`examples/`](https://github.com/SerhiiKorniienko/bullshit-detector/tree/main/examples), including an unedited audit of its own README that scored 3/10
- Runs in Claude Code CLI, the desktop Code tab, and other harnesses via skills.sh; also a Claude Code plugin
- Read-only, portable, MIT

Also publishes its [negative results](https://github.com/SerhiiKorniienko/bullshit-detector/tree/main/experiments) — including a measurement that 16 major news organisations block the crawler it depends on, and a follow-up on why the obvious workaround was rejected.