### PR TITLE
Add lacuna-music skill to Media & Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@
 - [moltdj](https://github.com/polaroteam/moltdj-skill) - AI music and podcast platform for autonomous agents — generate tracks, discover, earn tips and royalties.
 - [claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills) - Claude Code plugin for AI music creation covering lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.
 - [creative-director-skill](https://github.com/smixs/creative-director-skill) - AI creative director for ideation, scoring, recursive refinement, and storytelling frameworks.
+- [lacuna-music](https://github.com/JOYLINK-LTD/lacuna-toolkit/tree/main/skills/lacuna-music) - Generate AI music via the Lacuna Music API: full songs with vocals and lyrics, or instrumentals, with style prompts, task polling, and audio downloads.
 
 
 ## 🏥 Health & Life Sciences


### PR DESCRIPTION
Adds the `lacuna-music` skill to 🎬 Media & Content.

- Skill: https://github.com/JOYLINK-LTD/lacuna-toolkit/tree/main/skills/lacuna-music (SKILL.md with full parameter reference)
- What it does: lets Claude generate AI music through the [Lacuna](https://lacuna.fm) Music API — full songs with vocals and lyrics, or instrumentals — including style prompts, task status polling, and audio download.
- Open-source monorepo that also ships a TypeScript SDK, CLI, and MCP server, all published on npm.

One line appended to the end of the section, following the existing entry format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)