### PR TITLE
Add BeachFinder skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@
 - [glitternetwork/pinme](https://github.com/glitternetwork/skills/tree/main/pinme) - PinMe is a zero-config frontend deployment tool. No servers. No accounts. No setup.
 - [linkedin](https://github.com/Linked-API/linkedin-skills) - General-purpose LinkedIn automation via Linked API — fetch profiles, search people/companies, send messages, manage connections, create posts. Supports Sales Navigator.
 - [moodtrip-hotel-search](https://github.com/adiny/moodtrip-hotel-search) - Hotel search, comparison, reviews, pricing, and booking handoff via MoodTrip.ai MCP server. 12 tools including semantic search, room matching, and price intelligence.
+- [BeachFinder](https://github.com/troulin-a11y/beachfinder-skills) - Find and compare 184,900 swimming spots on [getbeachfinder.com](https://getbeachfinder.com) — beaches, lakes, bathing places — via the public BeachFinder MCP server. Live water temperature, wind, UV and wave signals, guides and source-backed local providers, 14 languages.
 - [review-claudemd](https://github.com/ykdojo/claude-code-tips/tree/main/skills/review-claudemd) - Review recent conversations to find improvements for CLAUDE.md files.
 - [hubspot-admin-skills](https://github.com/TomGranot/hubspot-admin-skills) - Skills for auditing, cleaning, enriching, and automating HubSpot CRM. Full audit → plan → execute → maintain workflow.
 - [SkillCheck-Free](https://github.com/olgasafonova/SkillCheck-Free) - Free SKILL.md validator with 30+ checks across structure, naming, and semantics. Catches common errors before deploying Claude Code skills.


### PR DESCRIPTION
Adds **BeachFinder** to Utility & Automation, alongside the similar moodtrip-hotel-search entry.

- Skill repo: https://github.com/troulin-a11y/beachfinder-skills
- Backing MCP (public, read-only, no auth): https://getbeachfinder.com/mcp
- Website: https://getbeachfinder.com

Find and compare 184,900 swimming spots worldwide with live conditions, guides and source-backed providers, in 14 languages.