### PR TITLE
Add browser-search to Utility & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@
 - [glitternetwork/pinme](https://github.com/glitternetwork/skills/tree/main/pinme) - PinMe is a zero-config frontend deployment tool. No servers. No accounts. No setup.
 - [linkedin](https://github.com/Linked-API/linkedin-skills) - General-purpose LinkedIn automation via Linked API — fetch profiles, search people/companies, send messages, manage connections, create posts. Supports Sales Navigator.
 - [moodtrip-hotel-search](https://github.com/adiny/moodtrip-hotel-search) - Hotel search, comparison, reviews, pricing, and booking handoff via MoodTrip.ai MCP server. 12 tools including semantic search, room matching, and price intelligence.
+- [browser-search](https://github.com/Johell1NS/browser-search) - Web search + browsing skill for AI agents: SearXNG multi-engine search, Camofox fast browsing, CloakBrowser stealth for Cloudflare/DataDome-protected sites. Self-hosted, free, unlimited.
 - [review-claudemd](https://github.com/ykdojo/claude-code-tips/tree/main/skills/review-claudemd) - Review recent conversations to find improvements for CLAUDE.md files.
 - [hubspot-admin-skills](https://github.com/TomGranot/hubspot-admin-skills) - Skills for auditing, cleaning, enriching, and automating HubSpot CRM. Full audit → plan → execute → maintain workflow.
 - [SkillCheck-Free](https://github.com/olgasafonova/SkillCheck-Free) - Free SKILL.md validator with 30+ checks across structure, naming, and semantics. Catches common errors before deploying Claude Code skills.


### PR DESCRIPTION
## What

Adds [browser-search](https://github.com/Johell1NS/browser-search) to the **Utility & Automation** section.

## Why

browser-search is a skill for AI agents (OpenCode, Claude Code, Cursor, OpenClaw) that gives them deterministic web access: SearXNG for multi-engine search, Camofox for fast structured browsing, and CloakBrowser to walk through anti-bot protected sites (Cloudflare, DataDome, Akamai). Fully self-hosted, free, unlimited, MIT licensed. Installable via `npx skills add Johell1NS/browser-search`.