### PR TITLE
Add patentfig-skill (patent figure generation & conversion)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@
 - [moltdj](https://github.com/polaroteam/moltdj-skill) - AI music and podcast platform for autonomous agents — generate tracks, discover, earn tips and royalties.
 - [claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills) - Claude Code plugin for AI music creation covering lyrics, Suno style prompts, per-stem mixing, mastering, and release distribution.
 - [creative-director-skill](https://github.com/smixs/creative-director-skill) - AI creative director for ideation, scoring, recursive refinement, and storytelling frameworks.
+- [patentfig-skill](https://github.com/TopLocalAI/patentfig-skill) - Generate USPTO/EPO-compliant patent figures from text via the PatentFig AI API — line art (PNG/SVG), vectorize to SVG/DXF/PDF, upscale, and convert to filing-ready formats.
 
 
 ## 🏥 Health & Life Sciences


### PR DESCRIPTION
Adds **[patentfig-skill](https://github.com/TopLocalAI/patentfig-skill)** to Media & Content.

Teaches agents to call the PatentFig AI REST API: generate USPTO/EPO-compliant patent figures from a text prompt (PNG or stroke-based SVG), vectorize raster drawings to SVG/DXF/vector PDF, AI-upscale, and convert to filing-ready formats. API key via env var; SKILL.md covers timeouts, credit costs, rate limits, and error handling. Docs: https://patentfig.ai/docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpyRDM5rKG2VczzDYnkxzs