### PR TITLE
Add marketingskills/seo skill collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@
 - [dev-gtm-claude-skills](https://github.com/Infrasity-Labs/dev-gtm-claude-skills) - Developer GTM skills for launch planning, positioning, and outbound workflows.
 - [great_cto](https://github.com/avelikiy/great_cto) - Claude Code SDLC plugin with specialist agents, commands, compliance workflows, and reusable learnings.
 - [linkedin-skills](https://github.com/sergebulaev/linkedin-skills) - LinkedIn marketing skill collection for posts, comments, audits, profile optimization, and content planning.
+- [marketingskills/seo](https://github.com/marketingskills/seo) - 20 open-source SEO operator skills for Claude Code, Codex, and Cursor: diagnose traffic decay, find keyword opportunities, build proposals, and generate client-ready reports via live GSC/GA4 data.
 - [skills-for-humanity](https://github.com/human-avatar/skills-for-humanity) - Structured reasoning methodology skills for logic, decisions, creativity, ethics, writing, and strategy.
 - [superseo-skills](https://github.com/inhouseseo/superseo-skills) - SEO skill collection for audits, briefs, article writing, E-E-A-T, topic clusters, and link building.
 - [toprank](https://github.com/nowork-studio/toprank) - SEO and Google Ads skills for audits, metadata, schema, bids, and CMS fixes.


### PR DESCRIPTION
Adds [marketingskills/seo](https://github.com/marketingskills/seo) to the Collections section alongside other SEO/marketing skill collections.

- 20 open-source SEO operator skills for Claude Code, Codex, and Cursor (SKILL.md format, Agent Skills spec)
- Install: `curl -fsSL marketingskills.net/seo | bash`
- Covers technical SEO audits, keyword opportunities, AI search (AEO/GEO), programmatic SEO, schema markup, refresh briefs, and client-ready reporting via live GSC/GA4 data
- MIT licensed, matches the existing `[name](url) - description` entry format

Affiliation disclosure: I maintain the marketingskills/seo project.