### PR TITLE
Add eu-ai-act skill (EU AI Act / Article 50 compliance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@
 - [ru-text](https://github.com/talkstream/ru-text) - Russian text quality: ~1,040 rules for typography, info-style, editorial, UX writing, business correspondence
 - [md2wechat](https://github.com/geekjourneyx/md2wechat-skill) - Convert Markdown into WeChat Official Account drafts with preview, image, and cover handling.
 - [buyer-eval](https://github.com/salespeak-ai/buyer-eval-skill) - Evaluate B2B vendors by interrogating agents, checking claims, and scoring weighted criteria.
+- [eu-ai-act](https://github.com/dankofly/eu-ai-act-skill) - EU AI Act compliance advisor for AI-generated content: Article 50 labeling duties, all exemptions as a no-label decision path, provider vs. deployer analysis, enforcement risk. Legal text verbatim from EUR-Lex; ships SKILL.md and AGENTS.md.
 
 
 ## 📘 Learning & Knowledge  


### PR DESCRIPTION
Adds **[eu-ai-act](https://github.com/dankofly/eu-ai-act-skill)** to Writing & Research.

**What it does:** EU AI Act compliance advisor for anyone publishing AI-assisted content. Walks the agent through the Article 50 decision path (applicable since August 2, 2026): scope check, provider vs. deployer role, all five transparency duties, and every written exemption. Includes ready-made disclosure snippets (DE/EN), an editorial-workflow template that unlocks the text exemption, and a content-log template.

**Quality:** legal text quoted verbatim from EUR-Lex (CELEX 32024R1689); Commission Guidelines (July 20, 2026) and the final Code of Practice incorporated; ships SKILL.md (Claude) and AGENTS.md (Codex); MIT. Hard guardrails against watermark stripping and fake human-authorship claims.

Transparency: I am the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)