### PR TITLE
Add humanizer-multilingual to Writing & Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@
 - [buyer-eval](https://github.com/salespeak-ai/buyer-eval-skill) - Evaluate B2B vendors by interrogating agents, checking claims, and scoring weighted criteria.
 - [en-zh-translation-polish](https://github.com/HoraceLuBFA/en-zh-translation-polish) - Translate English into idiomatic, translationese-free Chinese with bilingual paragraph output.
 - [humanizer-ru](https://github.com/Vladimir-Human/humanizer-ru) - Audit and rewrite Russian text using style patterns and deterministic markers.
+- [humanizer-multilingual](https://github.com/finestructure-ai/humanizer-multilingual) - Remove AI-writing tells in Spanish, Portuguese, French, German, Italian, Hebrew, Arabic, Russian, Japanese, and Chinese. Per-language calques, typography, register, and syntax patterns, graded P0/P1/P2, with a test corpus and counter-samples.
 - [bullshit-detector](https://github.com/SerhiiKorniienko/bullshit-detector) - Extract claims from media or PDFs, verify them against independent sources, and score BS risk.
 
 


### PR DESCRIPTION
Adds one entry to Writing & Research. Supersedes #524, which I opened without a description by mistake.

[humanizer-multilingual](https://github.com/finestructure-ai/humanizer-multilingual) removes AI-writing tells in Spanish, Portuguese, French, German, Italian, Hebrew, Arabic, Russian, Japanese and Chinese.

The list already has strong single-language tools (humanizer-ru, ru-text, en-zh-translation-polish). This one is complementary rather than overlapping: one install covering ten languages, built on the observation that models do not write bad Spanish, they write English wearing Spanish. So the patterns are calques, imported typography, register flattening and English syntax showing through, researched per language rather than translated from the English list.

- MIT, no telemetry, plain Markdown
- Findings graded P0/P1/P2, so a single weak signal is not reported as a verdict
- Test corpus includes counter-samples (legal, academic, literary, native Russian dashes) that must NOT be flagged
- Credits blader/humanizer and Wikipedia's Signs of AI writing, and links to marmbiz/humanizer-de and jurigis/avoid-ai-writing-multilingual where those are the better choice