### PR TITLE
docs: correct Suede skill count and scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
 - [crit](https://github.com/tomasz-tomczyk/crit) - Review and comment on plans, code diffs, and frontend, then send feedback directly to your agent.
 - [ax-extract-workflow](https://github.com/Necmttn/ax/tree/main/skills/ax-extract-workflow) - Reconstruct how a feature shipped from local ax session history.
-- [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - 71-skill pack for agent orchestration, code and release gates, design, marketing, Instagram growth, app shipping, and creator rights.
+- [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - Open-source skill pack for agent orchestration, code and release gates, design, marketing, Instagram growth, app shipping, and creator rights.
 - [Superdesign](https://github.com/superdesigndev/superdesign-skill) - Design skill that builds a design system from your codebase and iterates UI drafts on an infinite canvas.
 - [go-agent-skills](https://github.com/eduardo-sl/go-agent-skills) - 28 curated Go skills for code review, concurrency safety, testing, gRPC, and architecture.
 - [hivemind](https://github.com/activeloopai/hivemind) - Auto-generates skills from coding agent session traces for Claude Code, Codex, Cursor, and OpenClaw.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
 - [crit](https://github.com/tomasz-tomczyk/crit) - Review and comment on plans, code diffs, and frontend, then send feedback directly to your agent.
 - [ax-extract-workflow](https://github.com/Necmttn/ax/tree/main/skills/ax-extract-workflow) - Reconstruct how a feature shipped from local ax session history.
-- [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - Open-source skill pack for agent orchestration, code and release gates, design, marketing, Instagram growth, app shipping, and creator rights.
+- [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - 74-skill pack for design polish, code review with an A-F ship grade, CI gates, AI evals, SEO and AEO audits, marketing, and creator rights.
 - [Superdesign](https://github.com/superdesigndev/superdesign-skill) - Design skill that builds a design system from your codebase and iterates UI drafts on an infinite canvas.
 - [go-agent-skills](https://github.com/eduardo-sl/go-agent-skills) - 28 curated Go skills for code review, concurrency safety, testing, gRPC, and architecture.
 - [hivemind](https://github.com/activeloopai/hivemind) - Auto-generates skills from coding agent session traces for Claude Code, Codex, Cursor, and OpenClaw.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
 - [crit](https://github.com/tomasz-tomczyk/crit) - Review and comment on plans, code diffs, and frontend, then send feedback directly to your agent.
 - [ax-extract-workflow](https://github.com/Necmttn/ax/tree/main/skills/ax-extract-workflow) - Reconstruct how a feature shipped from local ax session history.
-- [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - 69-skill pack for agent orchestration, code and release gates, design, marketing, Instagram growth, app shipping, and creator rights.
+- [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - 71-skill pack for agent orchestration, code and release gates, design, marketing, Instagram growth, app shipping, and creator rights.
 - [Superdesign](https://github.com/superdesigndev/superdesign-skill) - Design skill that builds a design system from your codebase and iterates UI drafts on an infinite canvas.
 - [go-agent-skills](https://github.com/eduardo-sl/go-agent-skills) - 28 curated Go skills for code review, concurrency safety, testing, gRPC, and architecture.
 - [hivemind](https://github.com/activeloopai/hivemind) - Auto-generates skills from coding agent session traces for Claude Code, Codex, Cursor, and OpenClaw.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
 - [crit](https://github.com/tomasz-tomczyk/crit) - Review and comment on plans, code diffs, and frontend, then send feedback directly to your agent.
 - [ax-extract-workflow](https://github.com/Necmttn/ax/tree/main/skills/ax-extract-workflow) - Reconstruct how a feature shipped from local ax session history.
-- [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - 23-skill pack for agent orchestration with WIP collision detection and rollback trees.
+- [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - 67-skill pack for agent orchestration with WIP collision detection and rollback trees.
 - [Superdesign](https://github.com/superdesigndev/superdesign-skill) - Design skill that builds a design system from your codebase and iterates UI drafts on an infinite canvas.
 - [go-agent-skills](https://github.com/eduardo-sl/go-agent-skills) - 28 curated Go skills for code review, concurrency safety, testing, gRPC, and architecture.
 - [hivemind](https://github.com/activeloopai/hivemind) - Auto-generates skills from coding agent session traces for Claude Code, Codex, Cursor, and OpenClaw.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@
 - [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable interactive HTML replays with insights and PR links.
 - [crit](https://github.com/tomasz-tomczyk/crit) - Review and comment on plans, code diffs, and frontend, then send feedback directly to your agent.
 - [ax-extract-workflow](https://github.com/Necmttn/ax/tree/main/skills/ax-extract-workflow) - Reconstruct how a feature shipped from local ax session history.
-- [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - 67-skill pack for agent orchestration with WIP collision detection and rollback trees.
+- [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - 69-skill pack for agent orchestration, code and release gates, design, marketing, Instagram growth, app shipping, and creator rights.
 - [Superdesign](https://github.com/superdesigndev/superdesign-skill) - Design skill that builds a design system from your codebase and iterates UI drafts on an infinite canvas.
 - [go-agent-skills](https://github.com/eduardo-sl/go-agent-skills) - 28 curated Go skills for code review, concurrency safety, testing, gRPC, and architecture.
 - [hivemind](https://github.com/activeloopai/hivemind) - Auto-generates skills from coding agent session traces for Claude Code, Codex, Cursor, and OpenClaw.


### PR DESCRIPTION
## Summary

Update the accepted `suede-creator-skills` listing from the historical 23-skill description to the current 74-skill public pack.

The one-line description now reflects the repository's actual scope: design polish, code review with an A-F ship grade, CI gates, AI evals, SEO and AEO audits, marketing, and creator rights.

## Why

The linked repository's current `main` branch publishes 74 skill directories and 74 catalog entries. Its prior external listing predated the design, review, evals, and marketing packs.

## Testing

- confirmed 74 public skill folders, each with a `SKILL.md`, on the linked repository's current `main`
- confirmed 74 entries in the linked repository's public catalog (`mcp/catalog.json`)
- ran `git diff --check`

## Scope

README listing metadata only. The repository link and collection placement are unchanged.
