### PR TITLE
Add arabic-office-skills to Document Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - [pptx](https://github.com/anthropics/skills/tree/main/skills/pptx) - Read, generate, and adjust slides, layouts, templates.  
 - [xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
 - [revealjs-skill](https://github.com/ryanbbrown/revealjs-skill/tree/main) - Generate polished, professional presentations using the Reveal.js HTML presentation framework.
+- [arabic-office-skills](https://github.com/asadeisa/arabic-office-skills) - Three skills for generating PDF, Word, and PowerPoint files in Arabic and other right-to-left scripts, with correct letter shaping, RTL tables, and mixed Arabic/Latin text; includes a PNG preview for verifying the result.
 
 
 


### PR DESCRIPTION
### What this adds

[arabic-office-skills](https://github.com/asadeisa/arabic-office-skills) — three skills that produce `.pdf`, `.docx` and `.pptx` files in Arabic, and other right-to-left scripts, that render correctly.

### Why the existing document skills do not cover it

The `docx` / `pdf` / `pptx` skills already listed handle these formats, but none of them address right-to-left text. Arabic output fails in ways that are invisible in extracted text — the characters are all present and correct, only their shape and order are wrong: letters render disconnected instead of joined, lines inside a paragraph swap places, table columns mirror, the space around an English term disappears (`PostgreSQL و` → `PostgreSQLو`), and version numbers reverse (`Nuxt 3` → `3Nuxt`).

Each format needs a different fix. reportlab has no text engine and must be handed pre-shaped, visual-order glyphs; Word and PowerPoint have full bidirectional engines and need raw logical text plus direction flags written into the OOXML (`w:bidi`, `w:rtl`, `w:bidiVisual`, `w:cs` for Word; per-run `lang`, `rtl="1"`, `<a:cs>` for PowerPoint). Applying the PDF technique to Word or PowerPoint corrupts the file.

Each skill bundles a working Python library and a `preview()` that renders the output to PNG, since RTL defects can only be caught by looking at a render.

MIT licensed. No external service, no paid dependency.
