### PR TITLE
Add adversarial-code-loop: git-native adversarial dev loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@
 - [go-agent-skills](https://github.com/eduardo-sl/go-agent-skills) - 28 curated Go skills for code review, concurrency safety, testing, gRPC, and architecture.
 - [hivemind](https://github.com/activeloopai/hivemind) - Auto-generates skills from coding agent session traces for Claude Code, Codex, Cursor, and OpenClaw.
 - [mailtrap-skills](https://github.com/mailtrap/mailtrap-skills) - Agent skills for Mailtrap email sending, sandbox testing, domain setup, and contacts management.
+- [adversarial-code-loop](https://github.com/chpomob/adversarial-code-loop) - Git-native adversarial build → review → fix pipeline: one LLM writes code, another critiques the real git diff, fixes and validates until approval; model-agnostic (Claude Code, Codex, Gemini CLI, Hermes).
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
Adds a link-only entry for [chpomob/adversarial-code-loop](https://github.com/chpomob/adversarial-code-loop) under Development & Code Tools.

- SKILL.md at repo root (Agent Skills format), model-agnostic: Claude Code, Codex, Gemini CLI, Hermes
- Single runtime dependency: the `adversarial-common` sibling repo (shared engine) — the repo ships `scripts/install.sh` that bootstraps both side by side
- Includes runnable Python scripts, templates, references and a test suite
- MIT license

The suite (adversarial-plan, adversarial-spec, adversarial-code-review, adversarial-common) is designed so each skill works standalone with only adversarial-common as dependency.
