### PR TITLE
Add Shopify App Review Brief skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@
 - **[youtube-full](https://github.com/ZeroPointRepo/youtube-skills)** - YouTube transcripts, search, channel data, and playlists via TranscriptAPI. 100 free credits.
 - [alpha-insights](https://github.com/Ericyoung-183/alpha-insights) - Structured business research skill with strategy frameworks, evidence grading, and report output.
 - [claude-persona](https://github.com/takechanman1228/claude-persona) - Build AI persona panels for customer research, interviews, concept tests, and executive reports.
+- [shopify-review-triage](https://github.com/alfredtech2026/shopify-app-review-brief/blob/main/docs/skills/shopify-review-triage/SKILL.md) - Triage public low-star Shopify App Store reviews into a prioritized P0-P3 product and support brief that keeps every source link.
 
 
 ## 🔬 Scientific & Research Tools


### PR DESCRIPTION
Adds one link entry for the free, harness-neutral `shopify-review-triage` agent skill.

**What it does:** takes rows of public Shopify App Store review text and produces a prioritized P0-P3 product/support brief — incident risk, repeated friction, pricing confusion, feature requests, and an explicit "needs a human read" bucket — keeping the public source link on every item and labeling output "first pass" until a person checks it.

**Why it may be useful here:** it is a self-contained SKILL.md with no scripts, no network access, no API keys, and no dependencies, aimed at app teams and support/product owners who triage merchant feedback.

**Placement:** appended to the end of **Data & Analysis**, next to similar customer/ecommerce analysis skills (`claude-ecom`, `claude-persona`). It is not a code tool, so Development & Code Tools looked like a worse fit.

**Change:** README.md only, one line added. No other content touched.
