### PR TITLE
Add Handover Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@
 ## 🤝 Collaboration & Project Management
 - [agent-manager-skill](https://github.com/fractalmind-ai/agent-manager-skill) - Manage multiple local CLI AI agents via tmux sessions (start/stop/monitor/assign) with cron-friendly scheduling; no server required.
 - [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/git-pushing) - Automate git operations and repository interactions.
+- [Handover Skills](https://github.com/44-pixels/handover-mcp/tree/main/skills) - Four open Agent Skills for publishing, resuming, reviewing, and governing versioned context through Handover MCP or CLI.
 - [kanban-skill](https://github.com/mattjoyce/kanban-skill) - Markdown-based Kanban board with file-based cards, YAML frontmatter for status/priority/dependencies, and no database required.
 - [linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams with MCP tools, SDK scripts, and GraphQL fallbacks for reliable project tracking.
 - [linear-cli-skill](https://github.com/Valian/linear-cli-skill) - A skill teaching claude how to use linear-CLI (provided alongside the skill), meant to replace linear MCP.


### PR DESCRIPTION
Adds the source-linked Handover Agent Skills collection to Collaboration & Project Management.

The public repository contains four inspectable `SKILL.md` workflows for publishing durable context, resuming another actor's work, reviewing revision-anchored feedback, and governing agent access. The skills use the open Agent Skills format and work with Handover MCP or the `handover-sh` CLI.

Source: https://github.com/44-pixels/handover-mcp/tree/main/skills
Catalog: https://skills.handover.sh/