### PR TITLE
Add aaj-marketing-skills to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@
 - [AlterLab-Academic-Skills](https://github.com/AlterLab-IEU/AlterLab-Academic-Skills) - 186+ academic research skills across 13 domains for higher education and research.
 - [AlterLab_GameForge](https://github.com/AlterLab-IEU/AlterLab_GameForge) - 34 game development skills covering design, mechanics, and production pipelines.
 - [Claude Code SDK](https://github.com/SeifBenayed/claude-code-sdk) - Open-source, provider-agnostic CLI for AI agents. 13 providers, built-in tools, skill marketplace.
+- [aaj-marketing-skills](https://github.com/sarojkjha/aaj-marketing-skills) - 39 marketing skills across GTM, SEO/GEO, unit economics, retention and pipeline — 24 ship runnable Node engines that compute LTV:CAC and payback, weighted forecasts, A/B significance, and AI citation visibility rather than only prompting.
 - [career-ops](https://github.com/santifer/career-ops) - Job-search skill collection for JD evaluation, ATS resumes, portal scans, interview prep, and negotiation.
 - [Claude Skills](https://github.com/borghei/Claude-Skills) - Large cross-domain Claude skill collection for engineering, compliance, marketing, legal, finance, and more.
 - [claude-code-marketing-skills](https://github.com/cognyai/claude-code-marketing-skills) - Marketing skills for SEO audits, landing page review, competitor analysis, ad copy, and lead qualification.


### PR DESCRIPTION
Adds AAJ Marketing Skills to Collections.

39 marketing skills for AI agents. 24 ship runnable Node engines rather than
prompts alone — LTV:CAC and CAC payback, weighted pipeline forecasts, A/B test
significance and sizing, paid budget allocation against a CAC target, and AI
answer-engine citation scoring.

Verifiable in two commands, no configuration:

    npx skills add sarojkjha/aaj-marketing-skills --skill unit-economics
    node .agents/skills/unit-economics/resources/unit-economics.js

MIT. Works with Claude Code, Cursor, Codex, Windsurf.
Directory: https://www.skills.sh/sarojkjha/aaj-marketing-skills