### PR TITLE
Add OpenSource Review Suite to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@
 - [Skillselion](https://skillselion.com) - Curated directory of Claude Code agent skills, MCP servers, and plugin marketplaces.
 - [AugmentClaude](https://augmentclaude.com) - Free hand-picked marketplace of Claude Code skills, bundles, MCP servers, and agents.
 - [CreatorSkills](https://creatorskills.co) - Marketplace of SKILL.md skills for content creators covering YouTube, sponsorships, and growth.
+- [OpenSource Review Suite](https://github.com/priyank766/OpenSource-SKILL) - 8 agent skills for reviewing open-source pull requests — security, dependency, API-compat, test, performance, docs, and contributor-experience passes — each gated by a weighted 10-point filter so only 2-3 findings reach the maintainer.
 
 
 ## 🤝 Contribution


### PR DESCRIPTION
Eight agent skills for reviewing open-source pull requests: a general pass plus security, dependency, API-compatibility, test, performance, docs, and contributor-experience lenses.

Each skill is mostly detection procedure rather than advice, and a weighted 10-point filter drops everything below the skill's floor — so a medium PR produces two or three comments instead of a dozen.

Self-contained skills (install one or all eight), spec-compliant frontmatter, Apache-2.0. Appended to the end of Collections to match the section's existing order.