### PR TITLE
Add dev-report to Writing & Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@
 - [en-zh-translation-polish](https://github.com/HoraceLuBFA/en-zh-translation-polish) - Translate English into idiomatic, translationese-free Chinese with bilingual paragraph output.
 - [humanizer-ru](https://github.com/Vladimir-Human/humanizer-ru) - Audit and rewrite Russian text using style patterns and deterministic markers.
 - [bullshit-detector](https://github.com/SerhiiKorniienko/bullshit-detector) - Extract claims from media or PDFs, verify them against independent sources, and score BS risk.
+- [dev-report](https://github.com/delpicorp/dev-report) - Write up a coding session for a non-technical decision-maker: what was done, why that way, what is left, and what needs their call. Keeps the full engineering reasoning and defines every term at first use. Korean, Japanese, and Spanish command aliases included.
 
 
 ## 📘 Learning & Knowledge  

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@
 - [en-zh-translation-polish](https://github.com/HoraceLuBFA/en-zh-translation-polish) - Translate English into idiomatic, translationese-free Chinese with bilingual paragraph output.
 - [humanizer-ru](https://github.com/Vladimir-Human/humanizer-ru) - Audit and rewrite Russian text using style patterns and deterministic markers.
 - [bullshit-detector](https://github.com/SerhiiKorniienko/bullshit-detector) - Extract claims from media or PDFs, verify them against independent sources, and score BS risk.
-- [dev-report](https://github.com/delpicorp/dev-report) - Write up a coding session for a non-technical decision-maker: what was done, why that way, what is left, and what needs their call. Keeps the full engineering reasoning and defines every term at first use. Korean, Japanese, and Spanish command aliases included.
+- [dev-report](https://github.com/delpicorp/dev-report) - Explains a Claude Code session in plain language: what changed, why that approach was chosen, what is still unfinished or unverified, and what to do next. Every technical term is explained at first use. Korean, Japanese, and Spanish command aliases included.
 
 
 ## 📘 Learning & Knowledge  


### PR DESCRIPTION
Adds [dev-report](https://github.com/delpicorp/dev-report) to the end of **Writing & Research**. One line in the README; the skill lives in its own repository, like the other entries in that section.

### What it does

You finish a long Claude Code session. A dozen files changed and several implementation decisions were made along the way, but the end-of-session summary is file names and function names — accurate, and written for someone reading the diff alongside it. Asking for it "simply" removes the reasoning too.

dev-report explains the session in plain language instead: what was built or changed, why that approach was chosen, what is still unfinished or unverified, and what to do next. Technical terms aren't stripped out — they're explained the moment they first appear, so the reasoning survives.

Two rules do most of the work. Every finding leads with the raw artifact — the actual log line, the actual count — before it gets explained. And the section on how a problem was solved has to name the option that was rejected and what would have gone wrong, which is the only way to check a technical decision you can't read yourself.

### Notes

- Explicit-only. It does not hijack a casual "what did you just do?" — that question wants a two-line answer.
- Reports come out in whatever language the command was typed in. Command aliases ship for Korean, Japanese, and Spanish. File paths, function names, and error messages always stay in their original form.
- Installs as a Claude Code plugin (`/plugin marketplace add delpicorp/dev-report`) or as a plain skill. Two full worked example reports ship in the repo. MIT licensed.

*Updated 2026-08-04: reworded the entry and this description to lead with what the skill does rather than who it's for.*
