### PR TITLE
Add awesome-seedance-2.5-prompts-skills to Media & Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@
 - [claude-video-plus](https://github.com/abe238/claude-video-plus) - Ask a video a question and retrieve only the chapters, facts, and on-screen moments that answer it.
 - [ai-shortfilm-prompts](https://github.com/jnMetaCode/ai-shortfilm-prompts) - Turn any idea into a cinematic, model-ready video prompt for Sora, Kling, Veo, or Seedance.
 - [bria-ai](https://github.com/Bria-AI/bria-skill/tree/main/skills/bria-ai) - Generate, edit, and remove image backgrounds via the Bria.ai API — text-to-image, natural-language edits, and transparent PNGs.
+- [awesome-seedance-2.5-prompts-skills](https://github.com/AtlasCloudAI/awesome-seedance-2.5-prompts-skills) - Library of 150+ Seedance 2.5 video prompts, bundled with an installable skill that refines prompts, plans storyboards, and generates video.
 
 
 ## 🏥 Health & Life Sciences


### PR DESCRIPTION
Adds one entry to **🎬 Media & Content**.

[awesome-seedance-2.5-prompts-skills](https://github.com/AtlasCloudAI/awesome-seedance-2.5-prompts-skills) is a library of 150+ Seedance 2.5 video prompts (categorised by camera move, lighting, material, multi-character dialogue) that also ships an installable Agent Skill: it rewrites an idea into a model-ready prompt, plans a storyboard when the shot needs one, then generates the video. CC BY 4.0, README in 19 languages.

To be transparent about overlap: this list already includes `vibe-creating-skill` and `Vox Director` from the same team. Those are single-purpose skills (prompt rewriting; collage explainer videos). This entry is the prompt library for one specific model family, with the skill bundled alongside it — closest in kind to the existing `ai-shortfilm-prompts` and `video-prompting-skill` entries. Happy to drop it if you'd rather cap how many entries one team has here.

Disclosure: I work at Atlas Cloud, whose API the bundled skill calls by default; the prompt library is platform-agnostic.