### PR TITLE
fix: dexpaprika-api entry claims no rate limits; free tier is metered

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@
 - [chainaware-behavioral-prediction](https://github.com/ChainAware/behavioral-prediction-mcp) - ChainAware Skill for AI-powered tools to analyze wallet behaviour prediction,fraud detection and rug pull prediction.
 - [crowdcast](https://github.com/TheQmaks/crowdcast) - Multi-agent social simulation as a Claude Code skill. Spawns dozens of AI agents that argue, post, and react on a simulated platform, then writes a prediction report. Zero dependencies.
 - [coinpaprika-api](https://github.com/coinpaprika/skills/tree/main/coinpaprika-api) - Crypto market data for 12K+ coins, 350+ exchanges, tickers, OHLCV, historical prices. Free, no API key.
-- [dexpaprika-api](https://github.com/coinpaprika/skills/tree/main/dexpaprika-api) - Free DEX data across 34 chains: 30M+ pools, 27M+ tokens, real-time SSE streaming, OHLCV. No API key, no rate limits.
+- [dexpaprika-api](https://github.com/coinpaprika/skills/tree/main/dexpaprika-api) - Free DEX data across 36 chains: 36M+ pools, 33M+ tokens, real-time SSE streaming, OHLCV. No API key needed; free tier is 200K requests/month.
 - [gh-star-history](https://github.com/ykdojo/gh-star-history) - Visualize and compare GitHub star history as interactive charts, with regional breakdown of stargazers.
 - **[youtube-full](https://github.com/ZeroPointRepo/youtube-skills)** - YouTube transcripts, search, channel data, and playlists via TranscriptAPI. 100 free credits.
 - [alpha-insights](https://github.com/Ericyoung-183/alpha-insights) - Structured business research skill with strategy frameworks, evidence grading, and report output.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@
 - [chainaware-behavioral-prediction](https://github.com/ChainAware/behavioral-prediction-mcp) - ChainAware Skill for AI-powered tools to analyze wallet behaviour prediction,fraud detection and rug pull prediction.
 - [crowdcast](https://github.com/TheQmaks/crowdcast) - Multi-agent social simulation as a Claude Code skill. Spawns dozens of AI agents that argue, post, and react on a simulated platform, then writes a prediction report. Zero dependencies.
 - [coinpaprika-api](https://github.com/coinpaprika/skills/tree/main/coinpaprika-api) - Crypto market data for 12K+ coins, 350+ exchanges, tickers, OHLCV, historical prices. Free, no API key.
-- [dexpaprika-api](https://github.com/coinpaprika/skills/tree/main/dexpaprika-api) - Free DEX data across 36 chains: 36M+ pools, 33M+ tokens, real-time SSE streaming, OHLCV. No API key needed; free tier is 200K requests/month.
+- [dexpaprika-api](https://github.com/coinpaprika/skills/tree/main/dexpaprika-api) - DEX data across 36 chains: 36M+ pools, 33M+ tokens, SSE streaming, OHLCV. Free tier, no API key required.
 - [gh-star-history](https://github.com/ykdojo/gh-star-history) - Visualize and compare GitHub star history as interactive charts, with regional breakdown of stargazers.
 - **[youtube-full](https://github.com/ZeroPointRepo/youtube-skills)** - YouTube transcripts, search, channel data, and playlists via TranscriptAPI. 100 free credits.
 - [alpha-insights](https://github.com/Ericyoung-183/alpha-insights) - Structured business research skill with strategy frameworks, evidence grading, and report output.


### PR DESCRIPTION
One line. The `dexpaprika-api` entry is from my own PR #172, and I work on the API, so this is a self-correction.

**"no rate limits" is wrong.** The free tier is metered: a monthly request allowance plus 30 requests per minute, and stream updates count as requests as well. The entry now says "Free tier" and carries no number, because the allowance changed on 11 August and a list entry should not hold a figure that moves. Current limits: https://docs.dexpaprika.com/knowledge-base/rate-limits. "No API key required" is true and stays.

**"real-time SSE streaming" does not hold on the free tier.** Free data can be up to 15 seconds behind, and real-time is the paid tier. The entry now says "SSE streaming" with no latency promise.

**The coverage numbers are a release behind.** The entry claims "34 chains", "30M+ pools" and "27M+ tokens". Live:

```
$ curl -s https://api.dexpaprika.com/stats
{"chains":36,"factories":235,"pools":38564883,"tokens":35483652}
```

I put the rounded published figures in the line (36 chains, 36M+ pools, 33M+ tokens) rather than the exact live values, so it does not go stale again as the index grows.

The `coinpaprika-api` line above is untouched. Nothing else in the file changes.