### PR TITLE
Add pdp-audit — ecommerce product page UX audits

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@
 - [sequenzy-email-marketing](https://clawhub.ai/polnikale/sequenzy-email-marketing) - Operate Sequenzy email marketing workflows for subscribers, campaigns, sequences, and templates.
 - [TweetClaw](https://github.com/Xquik-dev/tweetclaw) - X/Twitter automation skill for search, posting, follower export, monitors, webhooks, and giveaways.
 - [browser-search](https://github.com/Johell1NS/browser-search) - Web search and browsing skill for AI agents with multi-engine search and stealth browsing.
+- [pdp-audit](https://github.com/llizell/pdp-audit) - Audits ecommerce product detail pages against 82 research-backed UX and conversion guidelines, producing a prioritized, evidence-based report with severity and effort ratings.
 
 ## 📰 Articles & Blog Posts
 


### PR DESCRIPTION
Adds [pdp-audit](https://github.com/llizell/pdp-audit) to Utility & Automation (happy to move it if another category fits better).

**What it does:** audits ecommerce product detail pages against 82 UX/conversion guidelines organized by page zone. Live-URL mode via Playwright (desktop + mobile screenshots, interaction testing, DOM inspection) with graceful fallback to screenshots-only. Produces one prioritized report: max 12 findings with severity, evidence, dev-ready recommendations, and effort ratings. MIT licensed, [sample report](https://github.com/llizell/pdp-audit/blob/main/examples/sample-report.md) included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)