### PR TITLE
Add auteur — cinematic web design skill with an executable anti-slop gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 - [claude-starter](https://github.com/raintree-technology/claude-starter) - Production-ready Claude Code configuration template with 40 auto-activating skills across 8 domains, TOON format support for 30-60% token savings, and native Zig encoder/decoder.
 - [move-code-quality-skill](https://github.com/1NickPappas/move-code-quality-skill) - Analyzes Move language packages against the official Move Book Code Quality Checklist for Move 2024 Edition compliance and best practices.
 - [oiloil-ui-ux-guide](https://github.com/oil-oil/oiloil-ui-ux-guide) - Modern UI/UX guidance and review skill with `guide` and `review` modes. Covers CRAP, task-first UX, HCI laws, interaction psychology, and modern minimal style.
+- [auteur](https://github.com/agiwhitelist/auteur) - Builds cinematic and award-level websites from a committed art direction, then gates every ship with an executable anti-slop linter and a throttled-CPU motion QA pass. Nine live showcase sites, all passing.
 - [claude-code-terminal-title](https://github.com/bluzername/claude-code-terminal-title) - Gives each Claud Code terminal window a dynamic title that describes the work being done so you don't lose track of what terminal window is doing what.
 - [charles-proxy-extract](https://github.com/wannabehero/charles-proxy-extract-skill) - Claude is able to extract and analyze HTTP traffic from Charles Proxy session files.
 - [debug-skill](https://github.com/AlmogBaku/debug-skill) - Give your AI agent a real debugger — breakpoints, stepping, variable inspection, and stack traces via CLI.


### PR DESCRIPTION
One line added to **🛠 Development & Code Tools**.

**[auteur](https://github.com/agiwhitelist/auteur)** — MIT, 675 stars.

Commits the art direction in writing before any markup, generates assets with local CLIs, then gates every ship with two executable checks: a zero-dependency anti-slop linter (fails on the 250–290° purple→blue gradient, `transition: all`, scroll-listener animation, WebGL with no `prefers-reduced-motion` branch, default fonts) and a Playwright motion pass on a throttled CPU.

Nine live showcase sites, each passing at 0 fails / 0 warns and re-checked in CI: https://agiwhitelist.github.io/auteur/

Install: `npx skills add agiwhitelist/auteur`