### PR TITLE
Add indian-stocks-fundamental-analysis (Data & Analysis)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@
 - **[youtube-full](https://github.com/ZeroPointRepo/youtube-skills)** - YouTube transcripts, search, channel data, and playlists via TranscriptAPI. 100 free credits.
 - [alpha-insights](https://github.com/Ericyoung-183/alpha-insights) - Structured business research skill with strategy frameworks, evidence grading, and report output.
 - [claude-persona](https://github.com/takechanman1228/claude-persona) - Build AI persona panels for customer research, interviews, concept tests, and executive reports.
+- [indian-stocks-fundamental-analysis](https://github.com/AlenSarangSatheesh/Indian-Stocks-Fundamental-Analysis-SKILL) - Sector-relative fundamental analysis of Indian & global listed companies; document-first ("never invent a number"), with forensic and IPO modes.
 
 
 ## 🔬 Scientific & Research Tools


### PR DESCRIPTION
Adds **indian-stocks-fundamental-analysis** under **Data & Analysis**.

Repo: https://github.com/AlenSarangSatheesh/Indian-Stocks-Fundamental-Analysis-SKILL

Sector-relative, multi-factor fundamental analysis of listed companies (India-first, works globally). Document-first ("never invent a number"), with Screen/Standard/Deep-dive/Forensic/IPO modes, 25 sector playbooks, and dependency-free Python helpers. Proper SKILL.md with YAML frontmatter, MIT-licensed.