### PR TITLE
Add mubu-integration to Document Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 
 
 
+- [mubu-integration](https://github.com/liuboacean/mubu-integration) - Mubu (幕布) outline CLI & AI Agent Skill — import/export Markdown with true round-trip fidelity, plus OPML/FreeMind export.  
 ## 🛠 Development & Code Tools
 - [web-artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code


### PR DESCRIPTION
Hi! I'd like to add **mubu-integration** to this list.

**What it is:** Mubu (幕布) outline CLI & AI Agent Skill — import/export Markdown with true round-trip fidelity, plus OPML/FreeMind export.

- Repo: https://github.com/liuboacean/mubu-integration
- 中文落地页: https://github.com/liuboacean/mubu-integration/blob/main/README.zh-CN.md
- Positioned as an AI Agent Skill (Claude Code / Agents), not just a CLI.

Accurate description (no exaggeration): outline↔Markdown sync with lossless round-trip, OPML/FreeMind export.

Thanks for maintaining this awesome list!
