### PR TITLE
Add lumify sports intelligence skill to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@
 - [crowdcast](https://github.com/TheQmaks/crowdcast) - Multi-agent social simulation as a Claude Code skill. Spawns dozens of AI agents that argue, post, and react on a simulated platform, then writes a prediction report. Zero dependencies.
 - [coinpaprika-api](https://github.com/coinpaprika/skills/tree/main/coinpaprika-api) - Crypto market data for 12K+ coins, 350+ exchanges, tickers, OHLCV, historical prices. Free, no API key.
 - [dexpaprika-api](https://github.com/coinpaprika/skills/tree/main/dexpaprika-api) - Free DEX data across 34 chains: 30M+ pools, 27M+ tokens, real-time SSE streaming, OHLCV. No API key, no rate limits.
+- [lumify](https://github.com/lumifyai/awesome-claude-skills/tree/lumify-skill/lumify) - Hosted sports intelligence MCP: schedules, live scores, sportsbook odds, public betting splits, and explainable bet confidence. Free instant key.
 - [gh-star-history](https://github.com/ykdojo/gh-star-history) - Visualize and compare GitHub star history as interactive charts, with regional breakdown of stargazers.
 - **[youtube-full](https://github.com/ZeroPointRepo/youtube-skills)** - YouTube transcripts, search, channel data, and playlists via TranscriptAPI. 100 free credits.
 - [alpha-insights](https://github.com/Ericyoung-183/alpha-insights) - Structured business research skill with strategy frameworks, evidence grading, and report output.


### PR DESCRIPTION
## Summary
Adds **lumify** under **Data & Analysis**, next to other API-backed data skills (`dexpaprika-api` / `coinpaprika-api`).

- Links to the external skill: https://github.com/lumifyai/awesome-claude-skills/tree/lumify-skill/lumify
- Prompt-only skill for Lumify's hosted read-only sports intelligence MCP (`https://lumify.ai/mcp`)
- Covers schedules, live scores, sportsbook odds, public betting splits, and explainable bet confidence
- Free instant key (no signup): https://lumify.ai/docs/ai
- Guardrails in the skill: no keys in chat, ask before metered MCP setup, not betting advice

## Test plan
- [ ] README link resolves to the skill `SKILL.md`
- [ ] Entry sits in Data & Analysis with no duplicates
- [ ] Description matches other API data skill blurbs