### PR TITLE
Add MemoryPlugin skill to Utility & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@
 - [sequenzy-email-marketing](https://clawhub.ai/polnikale/sequenzy-email-marketing) - Operate Sequenzy email marketing workflows for subscribers, campaigns, sequences, and templates.
 - [TweetClaw](https://github.com/Xquik-dev/tweetclaw) - X/Twitter automation skill for search, posting, follower export, monitors, webhooks, and giveaways.
 - [browser-search](https://github.com/Johell1NS/browser-search) - Web search and browsing skill for AI agents with multi-engine search and stealth browsing.
+- [MemoryPlugin](https://github.com/memoryplugin/agent-skills) - Long-term memory skill that recalls and stores the user's memories and searches imported chat history, shared across 21+ AI tools.
 
 ## 📰 Articles & Blog Posts
 


### PR DESCRIPTION
Adds the MemoryPlugin skill to the end of Utility & Automation.

The skill teaches Claude (Claude Code and other skill-supporting agents) to use the user's MemoryPlugin account: a hosted long-term memory shared across 21+ AI tools. It recalls relevant memories at task start, stores new ones during sessions, and searches imported ChatGPT/Claude/Gemini chat history. Ships as a standard SKILL.md skill and a Claude Code plugin, documented in the repo.

Disclosure: I'm the maker of MemoryPlugin. Submission prepared with the help of an AI agent.