### PR TITLE
Add perso-dubbing to Media & Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@
 - [claude-video-plus](https://github.com/abe238/claude-video-plus) - Ask a video a question and retrieve only the chapters, facts, and on-screen moments that answer it.
 - [ai-shortfilm-prompts](https://github.com/jnMetaCode/ai-shortfilm-prompts) - Turn any idea into a cinematic, model-ready video prompt for Sora, Kling, Veo, or Seedance.
 - [bria-ai](https://github.com/Bria-AI/bria-skill/tree/main/skills/bria-ai) - Generate, edit, and remove image backgrounds via the Bria.ai API — text-to-image, natural-language edits, and transparent PNGs.
+- [perso-ai/perso-dubbing-plugin](https://github.com/perso-ai/perso-dubbing-plugin) - Dub videos into other languages with lip-sync, extract and translate subtitles, and cut 9:16 short clips — subtitle work runs locally and free.
 
 
 ## 🏥 Health & Life Sciences


### PR DESCRIPTION
### What this adds

`perso-dubbing` — video localization from a coding agent. Three skills ship in
the repo:

- `dubbing` — voice-translates video into another language, with optional
  lip-sync and voice/background separation
- `srt` — extracts subtitles via STT, translates them, and burns styled
  subtitles onto the video
- `clip` — cuts short-form clips and reframes 16:9 to 9:16, or picks highlight
  moments from an STT transcript

Files, folders, and YouTube/TikTok URLs are all accepted as input.

### Where

Appended to the end of **🎬 Media & Content**, after `bria-ai`.

### Maintenance

Built and maintained by the Perso AI dev team. Currently v0.8.12, MIT licensed,
and it runs on Claude Code, Codex, Cursor, and Antigravity. Dubbing, lip-sync,
STT, and voice separation use Perso AI credits; subtitle translation, styling,
and clipping run locally.