### PR TITLE
Add BrotherSBE under Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@
 - [go-agent-skills](https://github.com/eduardo-sl/go-agent-skills) - 28 curated Go skills for code review, concurrency safety, testing, gRPC, and architecture.
 - [hivemind](https://github.com/activeloopai/hivemind) - Auto-generates skills from coding agent session traces for Claude Code, Codex, Cursor, and OpenClaw.
 - [mailtrap-skills](https://github.com/mailtrap/mailtrap-skills) - Agent skills for Mailtrap email sending, sandbox testing, domain setup, and contacts management.
+- [BrotherSBE](https://github.com/khalilmaaouni/BrotherSBE) - Senior backend and data engineering colleague skill: designs systems in order before code is written and holds the result to checks that actually run, reporting absent evidence as NO-DATA, never a pass.
 
 
 ## 📊 Data & Analysis


### PR DESCRIPTION
Adding BrotherSBE, a free MIT licensed Claude Code plugin that acts as a senior backend and data engineering colleague. It designs systems in order (purpose, process, architecture, data, expression, verification) before code is written, and holds the result to gates that actually run; absent evidence is reported as NO-DATA, never as a pass.

Repo: https://github.com/khalilmaaouni/BrotherSBE
One line added under the existing category, matching the list's row format. I am the author.
