### PR TITLE
Update pm-skills entry: 24 skills is stale, the library now ships 68

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@
 - [outline](https://github.com/sanjay3290/ai-skills/tree/main/skills/outline) - Search, read, create, and manage documents in Outline wiki instances (cloud or self-hosted).
 - [public-google-drive](https://github.com/zagmoai/public-google-drive) - Create and edit Google Docs and Sheets without Google sign-in. Documents are hosted on Memyard and viewable at shareable links.
 - [google-workspace-skills](https://github.com/sanjay3290/ai-skills/tree/main/skills) - Suite of Google Workspace integrations: Gmail, Google Calendar, Google Chat, Google Docs, Google Sheets, Google Slides, and Google Drive. Lightweight alternatives to full MCP servers with cross-platform OAuth.
-- [pm-skills](https://github.com/product-on-purpose/pm-skills) - 24 product management skills across the Triple Diamond lifecycle with agentskills.io spec compliance, templates, and MCP server support.
+- [pm-skills](https://github.com/product-on-purpose/pm-skills) - 68 product management skills across the Triple Diamond lifecycle, with 6 sub-agents, 12 workflows, and 200+ sample outputs. CI-validated skill contracts and agentskills.io spec compliance.
 - [Product-Manager-Skills](https://github.com/deanpeters/Product-Manager-Skills) - Product management skill library covering discovery, prioritization, PRDs, roadmap planning, and SaaS metrics.
 - [product-manager-skills](https://github.com/Digidai/product-manager-skills) - Senior PM agent with 6 knowledge domains, 12 templates, and 30+ frameworks covering discovery, strategy, delivery, SaaS metrics, PM career coaching (IC to CPO), and AI product craft.
 - [cup](https://github.com/krodak/clickup-cli) - ClickUp CLI for AI agents and humans. 40+ commands for tasks, sprints, time tracking. Ships as a Claude Code plugin.


### PR DESCRIPTION
Updates the existing pm-skills entry, which is out of date.

The entry says 24 skills. The library has since grown to 68 (30 lifecycle-phase, 11 foundation, 12 utility, 15 tool) and is on v2.31.1, so this refreshes the description to match. It also adds the sub-agent, workflow, and sample counts, and drops the MCP server mention since that component is now in maintenance mode and is no longer the recommended install path.

No new entry is added and nothing else in the list changes.

- Repo: https://github.com/product-on-purpose/pm-skills
- 68 skills, 6 sub-agents, 12 workflows, 200+ sample outputs
- Skill counts are enforced in CI in the source repo, so this figure stays accurate as the library changes
- Apache 2.0, follows the agentskills.io specification
