### PR TITLE
Add humanpen-skill under Writing & Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@
 - [en-zh-translation-polish](https://github.com/HoraceLuBFA/en-zh-translation-polish) - Translate English into idiomatic, translationese-free Chinese with bilingual paragraph output.
 - [humanizer-ru](https://github.com/Vladimir-Human/humanizer-ru) - Audit and rewrite Russian text using style patterns and deterministic markers.
 - [bullshit-detector](https://github.com/SerhiiKorniienko/bullshit-detector) - Extract claims from media or PDFs, verify them against independent sources, and score BS risk.
+- [humanpen-skill](https://github.com/humanpen/humanpen-skill) - Lowers a Word/PowerPoint/PDF document's AI-detection score so it reads as human-written.
 
 
 ## 📘 Learning & Knowledge  

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@
 - [en-zh-translation-polish](https://github.com/HoraceLuBFA/en-zh-translation-polish) - Translate English into idiomatic, translationese-free Chinese with bilingual paragraph output.
 - [humanizer-ru](https://github.com/Vladimir-Human/humanizer-ru) - Audit and rewrite Russian text using style patterns and deterministic markers.
 - [bullshit-detector](https://github.com/SerhiiKorniienko/bullshit-detector) - Extract claims from media or PDFs, verify them against independent sources, and score BS risk.
-- [humanpen-skill](https://github.com/humanpen/humanpen-skill) - Lowers a Word/PowerPoint/PDF document's AI-detection score so it reads as human-written.
+- [humanpen-skill](https://github.com/humanpen/humanpen-skill) - A document-level AI humanizer for .docx/.pptx — whole file, selected passages, or detector-flagged text.
 
 
 ## 📘 Learning & Knowledge  


### PR DESCRIPTION
Adds [humanpen-skill](https://github.com/humanpen/humanpen-skill) under **✍️ Writing & Research**.

An Agent Skill that lowers a Word/PowerPoint/PDF document's AI-detection score so it reads as human-written, keeping every fact, number, table and all formatting intact. Ships `SKILL.md`; works in Claude Code, Codex, Cursor and other clients. Apache-2.0.