### PR TITLE
Add sell-unused-tokens skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@
 - [CreatorSkills](https://creatorskills.co) - Marketplace of SKILL.md skills for content creators covering YouTube, sponsorships, and growth.
 
 
+- [sell-unused-tokens](https://github.com/ADWilkinson/sell-unused-tokens) - List leftover LLM API credits on tokensto.cash and cash out USDC.
+
 ## 🤝 Contribution
 
 If you have suggestions, improvements, or new resources to add:

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@
 - [CreatorSkills](https://creatorskills.co) - Marketplace of SKILL.md skills for content creators covering YouTube, sponsorships, and growth.
 
 
-- [sell-unused-tokens](https://github.com/galleonlabs/sell-unused-tokens) - List leftover LLM API credits on tokensto.cash and cash out USDC.
+- [sell-unused-tokens](https://github.com/galleonlabs/sell-unused-tokens) - List leftover LLM API credits on tokensto.cash and cash out USDC (Revolut, Monzo, Chime, Zelle direct; Venmo, Cash App, Wise, PayPal after a one-time USDCtoFiat Verify registration).
 
 ## 🤝 Contribution
 

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@
 - [CreatorSkills](https://creatorskills.co) - Marketplace of SKILL.md skills for content creators covering YouTube, sponsorships, and growth.
 
 
-- [sell-unused-tokens](https://github.com/ADWilkinson/sell-unused-tokens) - List leftover LLM API credits on tokensto.cash and cash out USDC.
+- [sell-unused-tokens](https://github.com/galleonlabs/sell-unused-tokens) - List leftover LLM API credits on tokensto.cash and cash out USDC.
 
 ## 🤝 Contribution
 


### PR DESCRIPTION
## Summary
Adds [sell-unused-tokens](https://github.com/ADWilkinson/sell-unused-tokens), a public agent skill for listing leftover LLM API capacity on [tokensto.cash](https://tokensto.cash) and cashing out USDC.

## Test plan
- [ ] Link resolves
- [ ] SKILL.md is present in the linked repo