### PR TITLE
Add hypergrok-trading-desk

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 
 
 ## 🛠 Development & Code Tools
+- [hypergrok-trading-desk](https://github.com/galleonlabs/hypergrok-trading-desk) - 7-role Hyperliquid trading desk: research, risk, ticketed execution, review. You approve every trade by ticket id.
 - [web-artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.


### PR DESCRIPTION
Adds [hypergrok-trading-desk](https://github.com/galleonlabs/hypergrok-trading-desk) under Development & Code Tools.

7-role Hyperliquid trading desk: research, risk, ticketed execution, review. You approve every trade by ticket id. MIT. Official Galleon Labs source.

Related: #590 (sell-unused-tokens), #591 (usdctofiat-cashout).