### PR TITLE
Update PM Skills entry: 771 → 1,153 skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@
 - [agent-starter](https://github.com/sneg55/agent-starter) - Skills, hooks, and templates for bootstrapping AI-agent-friendly projects.
 - [kc_ai_skills](https://github.com/KerberosClaw/kc_ai_skills) - Traditional Chinese-first collection of 22 reusable agent skills with bilingual documentation.
 - [goose-skills](https://github.com/gooseworks-ai/goose-skills) - 125 growth and GTM skills for ads, content, lead generation, outreach, research, and SEO.
-- [PM Skills](https://github.com/mohitagw15856/pm-claude-skills) - 771 professional skills across 35 professions, including PRDs, postmortems, and negotiation simulators.
+- [PM Skills](https://github.com/mohitagw15856/pm-claude-skills) - 1,153 professional skills across 35 professions, including PRDs, postmortems, and negotiation simulators.
 - [Marketing Skills](https://github.com/coreyhaines31/marketingskills) - 49 marketing skills for AI agents covering SEO, copywriting, cold email, pricing, CRO, ads, and analytics.
 - [NotFair](https://github.com/nowork-studio/NotFair) - Open-source Claude Code skills for SEO, Google Ads, and Meta Ads with live data connectors.
 - [agent37-skills-collection](https://github.com/agent37-platform/agent37-skills-collection) - Claude Code plugin marketplace with YC advisor, local review, and related agent plugins.


### PR DESCRIPTION
The PM Skills entry has gone stale — it says 771 skills, and the library is now at 1,153.

This changes the number only. Category, wording and the rest of the description are untouched.

Verifiable at the source: https://github.com/mohitagw15856/pm-claude-skills — the count is generated from the `skills/` directory on every build, and a CI drift check fails the build if any doc disagrees with it.

Thanks for maintaining the list.
