### PR TITLE
Add ai-sales-skills to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@
 
 ## 🗂️ Collections
 
+- [ai-sales-skills](https://github.com/Marchenko-sales/ai-sales-skills) - 6 skills for the full B2B sales cycle: segment prospecting, pre-outreach company dossiers, decision-maker search, cold outreach with a follow-up cadence, qualification, and objection handling. Worked input/output example in every skill.
 - [@clawfu/mcp-skills](https://github.com/guia-matthieu/clawfu-skills) - 169 expert-sourced marketing skills (Dunford, Schwartz, Ogilvy, Cialdini) as MCP server with brand memory.
 - [wondelai/skills](https://github.com/wondelai/skills) - 25 agent skills for UX design, marketing/CRO, sales, product strategy, and growth based on books by Norman, Cialdini, Ries, Hormozi, and others.
 - [devmarketing-skills](https://github.com/jonathimer/devmarketing-skills) - 33 skills for developer marketing — HN strategy, technical tutorials, docs-as-marketing, Reddit engagement, developer onboarding, newsletters, and SEO for devtools.


### PR DESCRIPTION
Adds [ai-sales-skills](https://github.com/Marchenko-sales/ai-sales-skills) to the Collections section.

Six Agent Skills covering the full B2B sales cycle, built and used daily by a sales team at a fintech company:

- **segment-company-search** - finds candidate companies in a niche, verifies each against strict ICP criteria, outputs a prioritized table
- **company-context** - pre-outreach dossier: legal entity, reputation, contact channels, current vendor, buying signals with dates and links
- **b2b-lead-contacts** - named decision-makers, LinkedIn and Telegram, corporate email pattern with confidence levels
- **cold-outreach** - first message plus a 4-touch follow-up cadence, CTA typology, anti-template rules across contacts at one company
- **qualification-objections** - three qualification buckets, discovery questions, principles for common objections
- **stop-slop-ru** - removes AI-writing patterns from Russian copy before sending

The skills hand results to each other: the dossier feeds the outreach, the outreach feeds qualification. Every skill includes a worked input/output example and explicit honesty rules that forbid inventing facts about a prospect.

Skill bodies are in Russian (the team's working language; Claude reads them natively and answers in the user's language), documentation and frontmatter descriptions are in English. No paid APIs, CC BY 4.0.

Disclosure: this PR was prepared with Claude Code assistance; the library is the author's own work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)